### PR TITLE
fix(auto-improve): expand allowed-tools

### DIFF
--- a/.github/workflows/auto-improve.yml
+++ b/.github/workflows/auto-improve.yml
@@ -65,8 +65,15 @@ jobs:
             Bash(mkdir *),
             Bash(cat *),
             Bash(echo *),
+            Bash(unzip *),
+            Bash(wc *),
+            Bash(ls *),
+            Bash(head *),
+            Bash(find *),
+            Bash(rm *),
             Read,
             Write,
+            Edit,
             Glob
 
       - name: Upload Claude session transcript


### PR DESCRIPTION
## Summary
- Add `unzip`, `wc`, `ls`, `head`, `find`, `rm`, and `Edit` to the auto-improve workflow's `--allowed-tools` list.
- These are needed when the agent unpacks run logs, inspects artifacts, and edits proposal files; their absence was stalling runs on approval prompts.

## Test plan
- [ ] Trigger the Auto-Improvement Agent workflow manually and confirm it completes without tool-permission errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)