### PR TITLE
fix(claude.yml): merge duplicate claude_args

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,8 +47,6 @@ jobs:
           additional_permissions: |
             actions: read
 
-          claude_args: '--model ${{ steps.model.outputs.id }}'
-
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
@@ -57,6 +55,7 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: >-
+            --model ${{ steps.model.outputs.id }}
             --allowed-tools
             Bash(git checkout:*),
             Bash(git switch:*),


### PR DESCRIPTION
## Summary
- The Claude Code workflow had `claude_args` defined twice, causing GitHub Actions to reject it as an invalid workflow file (`Line 59: 'claude_args' is already defined`).
- Merge both into a single block so `--model` and `--allowed-tools` are passed together.

## Test plan
- [ ] Confirm GitHub Actions parses the workflow (no "Invalid workflow file" error).
- [ ] Trigger an @claude mention and confirm the run uses the configured model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)