### PR TITLE
feat(auto-improve): persistent issue tracker with lifecycle + dedupe

### DIFF
--- a/.github/workflows/auto-improve.yml
+++ b/.github/workflows/auto-improve.yml
@@ -1,4 +1,4 @@
-name: Auto-Improvement Agent
+name: Auto-Improvement Tracker
 
 on:
   schedule:
@@ -34,7 +34,13 @@ jobs:
           id=$(yq ".model_aliases.\"$alias\" // \"$alias\"" auto_tune_config.yml)
           echo "id=$id" >> "$GITHUB_OUTPUT"
 
-      - name: Run Auto-Improvement Agent
+      - name: Resolve verification window
+        id: verify
+        run: |
+          n=$(yq '.tracking.verify_runs // 2' auto_tune_config.yml)
+          echo "runs=$n" >> "$GITHUB_OUTPUT"
+
+      - name: Run Auto-Improvement Tracker
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -44,13 +50,16 @@ jobs:
 
           prompt: |
             Read the file `scripts/auto-improve-prompt.md` — it contains your
-            full instructions for the auto-improvement task. Follow every step
-            exactly, including the delivery model: one umbrella issue with the
-            global report, plus one focused PR per improvement subject. Do not
-            create a `proposals/` directory or bundle everything into a single
-            PR.
+            full instructions. You are the auto-improvement *tracker*: each
+            recurring problem is managed as a persistent GitHub issue that
+            moves through raised → pr-open → merged → solved. There is no
+            umbrella issue. Before raising any issue, dedupe against existing
+            ones (by fingerprint key, then by semantic match). Reconcile state
+            of existing issues on every run and close those whose fix has been
+            verified for VERIFY_RUNS successive clean runs.
 
             CONVERSATION_LIMIT=${{ github.event.inputs.conversation_limit || '20' }}
+            VERIFY_RUNS=${{ steps.verify.outputs.runs }}
             Workflow logs to parse: all discoverable runs (no cap)
             Today's date: $(date +%Y-%m-%d)
 
@@ -61,6 +70,8 @@ jobs:
             Bash(gh run:*),
             Bash(gh pr:*),
             Bash(gh issue:*),
+            Bash(gh label:*),
+            Bash(jq:*),
             Bash(git *),
             Bash(pip install*),
             Bash(python3 *),

--- a/auto_tune_config.yml
+++ b/auto_tune_config.yml
@@ -27,3 +27,8 @@ auto_improve:
   # are always analyzed in full (no cap).
   default_conversation_limit: 20
   schedule: "0 3 * * 0"
+
+tracking:
+  # Number of successive clean runs (no recurrence) required after a fix PR
+  # merges before the tracker closes the issue as auto-improve:solved.
+  verify_runs: 2

--- a/scripts/auto-improve-prompt.md
+++ b/scripts/auto-improve-prompt.md
@@ -1,89 +1,128 @@
-# Auto-Improvement Agent Prompt
+# Auto-Improvement Tracker Prompt
 
-You are the auto-improvement agent for this Claude Code workspace. Your goal
-is to analyze recent workflow runs — including both the CI logs and the
-detailed Claude Code session transcripts — identify concrete, actionable
-improvements, and deliver them as:
+You are the auto-improvement tracker for this Claude Code workspace. Unlike a
+one-shot report generator, your job is to **follow improvement subjects across
+multiple runs** using the GitHub Issues system as persistent state. Each real
+problem becomes one targeted issue that moves through a lifecycle:
 
-1. **One umbrella GitHub issue** containing the global report (summary of
-   findings, metrics, and a list of every spawned PR with a one-line
-   description).
-2. **One focused PR per improvement subject**, each containing the actual
-   code changes (not proposals) and a detailed explanation in the PR body.
+```
+raised  →  pr-open  →  merged  →  verified-solved (closed)
+```
 
-Do **not** dump everything into a single bundled PR or place files under a
-`proposals/` directory. Each improvement must stand on its own as a merge-ready
-change.
+You are responsible for:
+1. **Discovering** new problems from recent workflow logs + Claude Code session transcripts.
+2. **Deduplicating** — before raising a new issue, check whether an existing
+   auto-improve issue already covers the same problem and update it instead.
+3. **Advancing state** — move issues from `pr-open` → `merged` when their PR
+   lands, and from `merged` → closed/`verified-solved` when the problem no
+   longer recurs.
+4. **Shipping fixes** — for new or `raised` issues you can fix automatically,
+   open a focused PR that links back to the issue via `Fixes #<num>`.
 
-## Step 1 — Fetch workflow run IDs
+There is **no umbrella issue**. Each improvement subject has its own persistent
+issue that lives until the fix is verified.
 
-Fetch **all** recent workflow runs (no cap on workflows). Pagination is
-enabled so the list is limited only by GitHub's retention window and the
-default API window (typically the last several hundred runs is fine —
-don't try to pull years of history).
+---
+
+## Labels and state machine
+
+All issues managed by this workflow carry the base label `auto-improve`. Their
+current lifecycle state is encoded in a second label:
+
+| Label                        | Meaning                                                                  |
+| ---------------------------- | ------------------------------------------------------------------------ |
+| `auto-improve:raised`        | Issue exists, no fix PR yet.                                             |
+| `auto-improve:pr-open`       | A PR referencing this issue is open.                                     |
+| `auto-improve:merged`        | The fix PR merged; issue is in the verification window.                  |
+| `auto-improve:solved`        | Verified not recurring for `VERIFY_RUNS` successive runs. Issue closed.  |
+
+Label invariants (enforce these every run):
+- At most one state label per issue.
+- `auto-improve` is always present.
+- Closed issues only carry `auto-improve:solved` (never `:raised`, `:pr-open`,
+  `:merged`).
+
+If any base label or state label is missing from the repository, create it at
+the start of the run:
 
 ```bash
+for L in auto-improve auto-improve:raised auto-improve:pr-open auto-improve:merged auto-improve:solved; do
+  gh label create "$L" --force 2>/dev/null || true
+done
+```
+
+---
+
+## Issue body contract
+
+Every tracked issue carries a structured, machine-readable fingerprint block
+and a structured body. This is how future runs find and update it.
+
+```markdown
+<!-- auto-improve:fingerprint
+key: <stable-slug-derived-from-the-problem>
+category: <reliability|cost_reduction|new_workflow|deterministic_script|subagent_skill|capability_gap|docs_convention>
+-->
+
+## Problem
+<1–3 sentence description of the recurring problem>
+
+## Status
+- First observed: <YYYY-MM-DD>
+- Last observed: <YYYY-MM-DD>
+- Occurrences: <N>
+- Verification streak (clean runs since merge): <0 until merged>
+- State: raised | pr-open | merged | solved
+
+## Evidence
+- <bullet per observation, with run ID and short excerpt>
+
+## Related
+- PR: #<num> (added once a fix PR is opened)
+```
+
+The fingerprint `key` must be a short, stable slug you can regenerate from the
+same problem across runs (e.g. `gh-pr-tool-not-allowed`,
+`workflow-log-parser-empty-output`). Generate it deterministically from the
+normalized problem title + category.
+
+---
+
+## Step 1 — Discover data
+
+Fetch runs and parse them exactly as in the previous tracker generation.
+
+```bash
+pip install -q anthropic pyyaml
+
 gh api repos/$GITHUB_REPOSITORY/actions/runs \
   --paginate \
   --jq '.workflow_runs[] | {id: .id, name: .name, created_at: .created_at, conclusion: .conclusion}' \
   > /tmp/runs.jsonl
 echo ">>> Total runs discovered: $(wc -l < /tmp/runs.jsonl)"
-```
 
-Collect all run IDs into a list (`$RUN_IDS`). There is **no upper limit**
-for workflow log parsing — all discovered runs are analyzed in Step 2.
+RUN_IDS=$(jq -r '.id' /tmp/runs.jsonl)
 
-The separate `$CONVERSATION_LIMIT` (provided to you in the task invocation,
-default 20) only caps how many **Claude Code session transcripts** are
-downloaded in Step 3.
-
-## Step 2 — Parse every run log with the log parser
-
-Iterate over **all** discovered run IDs — no slicing.
-
-```bash
-pip install -q anthropic pyyaml
 WORKFLOWS_PARSED=0
 for RUN_ID in $RUN_IDS; do
-  echo "=== Parsing run $RUN_ID ==="
   gh run view "$RUN_ID" --log 2>/dev/null \
     | python3 scripts/parse-workflow-log.py \
-    >> /tmp/all-insights.jsonl || echo '{"summary":"fetch failed","insights":[]}' >> /tmp/all-insights.jsonl
+    >> /tmp/all-insights.jsonl \
+    || echo '{"summary":"fetch failed","insights":[]}' >> /tmp/all-insights.jsonl
   WORKFLOWS_PARSED=$((WORKFLOWS_PARSED + 1))
 done
 echo ">>> Workflows parsed: $WORKFLOWS_PARSED"
-```
 
-## Step 3 — Fetch and parse Claude Code session transcripts (cap: $CONVERSATION_LIMIT)
-
-Walk the run list in order (newest first, as returned by the API) and
-download the `claude-transcript` artifact where available. **Stop as soon
-as `$CONVERSATION_LIMIT` transcripts have been successfully analyzed.**
-Runs without a transcript artifact don't count toward the cap — keep
-going until you either hit the limit or exhaust the run list.
-
-```bash
 CONVERSATIONS_ANALYZED=0
 for RUN_ID in $RUN_IDS; do
-  if [ "$CONVERSATIONS_ANALYZED" -ge "$CONVERSATION_LIMIT" ]; then
-    echo ">>> Reached conversation cap ($CONVERSATION_LIMIT); stopping transcript collection."
-    break
-  fi
-
+  if [ "$CONVERSATIONS_ANALYZED" -ge "$CONVERSATION_LIMIT" ]; then break; fi
   ARTIFACT_ID=$(gh api repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/artifacts \
     --jq '.artifacts[] | select(.name == "claude-transcript") | .id' 2>/dev/null | head -1)
-
-  if [ -z "$ARTIFACT_ID" ]; then
-    continue  # no transcript for this run — not counted against the cap
-  fi
-
-  echo "=== Fetching transcript for run $RUN_ID ==="
+  if [ -z "$ARTIFACT_ID" ]; then continue; fi
   mkdir -p /tmp/transcripts/$RUN_ID
   gh api repos/$GITHUB_REPOSITORY/actions/artifacts/$ARTIFACT_ID/zip \
     > /tmp/transcripts/$RUN_ID/transcript.zip 2>/dev/null
-  unzip -q /tmp/transcripts/$RUN_ID/transcript.zip \
-    -d /tmp/transcripts/$RUN_ID/ 2>/dev/null || true
-
+  unzip -q /tmp/transcripts/$RUN_ID/transcript.zip -d /tmp/transcripts/$RUN_ID/ 2>/dev/null || true
   python3 scripts/parse-claude-transcript.py /tmp/transcripts/$RUN_ID/ \
     >> /tmp/all-transcript-insights.jsonl \
     || echo '{"summary":"parse failed","tool_call_count":0,"top_tools":[],"insights":[]}' \
@@ -93,125 +132,184 @@ done
 echo ">>> Conversations analyzed: $CONVERSATIONS_ANALYZED (cap: $CONVERSATION_LIMIT)"
 ```
 
-### Workflow Setup (sanity check)
-
-For transcripts to be available, every workflow invoking `claude-code-action`
-must end with an upload step like:
-
-```yaml
-- name: Upload Claude session transcript
-  if: always()
-  uses: actions/upload-artifact@v4
-  with:
-    name: claude-transcript
-    path: ~/.claude/projects/**/*.jsonl
-    if-no-files-found: ignore
-    retention-days: 30
-```
-
-If any active workflow is missing it, that alone becomes one of your
-improvement subjects (see Step 5).
-
-## Step 4 — Synthesize and cluster into improvement subjects
-
-Read all insights from both `/tmp/all-insights.jsonl` (workflow logs) and
-`/tmp/all-transcript-insights.jsonl` (Claude session transcripts). Group them
-into **improvement subjects** where each subject is:
-
-- A single, focused change that can be shipped as one PR.
-- Supported by **at least 2 observed instances** or **1 high-confidence
-  instance** with strong evidence.
-- Scoped narrowly enough that a reviewer can understand it in a few minutes.
-
-Suggested categories (a subject can fit more than one):
-
-- `reliability` — recurring errors, flaky steps, missing tool permissions
-- `cost_reduction` — swap a cheaper model where quality is unaffected
-- `new_workflow` — repeated manual work worth automating
-- `deterministic_script` — Claude repeating the same steps; a script is faster
-- `subagent_skill` — capability worth extracting into a skill/subagent
-- `capability_gap` — a missing tool or API causing workarounds
-- `docs_convention` — a rule or convention that should live in `CLAUDE.md`
-
-Prefer insights that are corroborated by **both** log and transcript sources.
-
-Aim for **3–7 improvement subjects** total. If you find more, pick the
-highest-impact ones and mention the rest in the umbrella issue as "deferred".
-
-## Step 5 — Ship each subject as its own PR
-
-For **each** improvement subject, in order:
-
-1. `git checkout main && git pull`
-2. Create a branch: `auto-improve/<date>-<short-slug>` (e.g.
-   `auto-improve/2026-04-05-add-gh-pr-allowed-tool`).
-3. Make the **actual** edits — modify the real files (`.github/workflows/*`,
-   `scripts/*`, `CLAUDE.md`, etc.). Do not place anything under a `proposals/`
-   directory.
-4. Keep the change minimal and self-contained. If two subjects would touch
-   the same lines, merge them into one subject instead.
-5. Commit with a clear message explaining the *why*.
-6. Push the branch and open a PR with:
-   - **Title**: concise, imperative (`fix:`, `feat:`, `chore:` prefix).
-   - **Body** (required sections):
-     - `## Problem` — what the logs/transcripts showed, with run IDs or
-       excerpts as evidence.
-     - `## Change` — what this PR modifies and why.
-     - `## Files` — bulleted list of modified files.
-     - `## Evidence` — number of observed instances, sources (log vs.
-       transcript), and confidence level (low / medium / high).
-   - Do **not** reference the umbrella issue yet — you'll link it after the
-     issue is created in Step 6.
-
-Record each opened PR's number and title in a local variable so Step 6 can
-reference them.
-
-If a subject cannot be implemented as a code change (e.g. it's purely a
-recommendation or needs human judgment), do **not** open an empty PR. Instead,
-list it in the umbrella issue under a "Recommendations (no PR)" section.
-
-## Step 6 — Open the umbrella issue with the global report
-
-After all PRs are opened, create **one** GitHub issue titled
-`Auto-improvement report <date>` with this structure:
-
-```markdown
-## Summary
-<2–4 sentences describing the scan: how many runs analyzed, overall health,
-biggest themes>
-
-## Pipeline metrics
-- Workflows parsed: <N>
-- Conversations analyzed: <N>
-- Improvement subjects identified: <N>
-- PRs opened: <N>
-
-## Proposed changes
-| PR | Category | One-line description |
-| -- | -------- | -------------------- |
-| #<num> | reliability | Add missing `gh pr:*` to auto-improve allowed-tools |
-| #<num> | cost_reduction | Switch log parser default to haiku |
-| ...    | ...          | ...                                               |
-
-## Recommendations (no PR)
-<optional — subjects that need human judgment>
-
-## Deferred
-<optional — lower-priority subjects not shipped this run>
+If both counts are 0, skip to Step 7 and exit without touching issues.
 
 ---
-Generated by the Auto-Improvement Agent.
+
+## Step 2 — Cluster raw insights into problem candidates
+
+Read `/tmp/all-insights.jsonl` and `/tmp/all-transcript-insights.jsonl`, group
+related entries, and produce a list of **problem candidates** in memory. Each
+candidate has:
+
+- `title` — short imperative description
+- `category` — one of the categories from the fingerprint table
+- `key` — stable slug you generate from the title + category
+- `evidence` — list of `{run_id, excerpt}` tuples (at least 1)
+- `confidence` — low / medium / high
+
+Require **≥ 2 observations** OR **1 high-confidence observation with strong
+evidence** before a candidate can become an issue. Lower-signal candidates are
+discarded this run (they'll surface again next week if the problem is real).
+
+---
+
+## Step 3 — Load existing auto-improve issues
+
+```bash
+gh issue list \
+  --label auto-improve \
+  --state all \
+  --limit 500 \
+  --json number,title,body,labels,state,closedAt,url \
+  > /tmp/existing-issues.json
 ```
 
-Use `gh issue create` to open it, then **edit each PR body** (via
-`gh pr edit <num> --body`) to append a line `Part of #<issue-num>` so the
-links go both ways.
+Parse the fingerprint block out of each issue body to build a map from
+`key → issue`. Keep both open and recently-closed issues — the reconciliation
+step below uses closed `solved` issues to detect regressions.
 
-## Step 7 — Exit criteria and guardrails
+---
 
-- If both `WORKFLOWS_PARSED` and `CONVERSATIONS_ANALYZED` are 0, **stop**.
-  Open a single issue titled `Auto-improvement report <date> — no data` with
-  a brief explanation of why nothing was analyzed. Do not open any PRs.
+## Step 4 — Reconcile candidates with existing issues
+
+For each candidate from Step 2:
+
+1. **Key match**: if an existing issue has the same fingerprint `key`, it is
+   the match. Use it.
+2. **Semantic match (fallback)**: if no exact key match, compare the candidate
+   title and category to each open issue's title + category. If they describe
+   the same underlying problem (use your judgment — you are an LLM, this is
+   what you are for), treat as a match and prefer the existing issue's key.
+3. **No match** → the candidate is new.
+
+### If matched to an open issue (`raised`, `pr-open`, or `merged`)
+
+Update the existing issue in place:
+- Append a new bullet to the `## Evidence` section with today's date and the
+  new run excerpts.
+- Bump `Occurrences` in the `## Status` section.
+- Update `Last observed` to today.
+- If the issue was in `merged` state and the problem is still appearing, this
+  is a **regression**: relabel from `auto-improve:merged` back to
+  `auto-improve:raised`, reset `Verification streak` to 0, and add a comment
+  explaining the regression with links to the recurring run IDs.
+
+Do **not** create a duplicate issue.
+
+### If matched to a closed (`solved`) issue
+
+The problem has come back after being verified fixed. **Reopen** the issue,
+relabel to `auto-improve:raised`, append a new evidence bullet, and add a
+comment: `Regression detected after previous verification.`
+
+### If no match → create a new issue
+
+```bash
+gh issue create \
+  --title "<short imperative title>" \
+  --label auto-improve \
+  --label auto-improve:raised \
+  --body-file /tmp/issue-body-<slug>.md
+```
+
+The body must follow the **Issue body contract** above, including the
+`<!-- auto-improve:fingerprint ... -->` block.
+
+---
+
+## Step 5 — Advance state of existing issues
+
+Independent of new candidate reconciliation, walk all **open** auto-improve
+issues and move them along the lifecycle where appropriate.
+
+### `raised` → `pr-open`
+If the issue now has a linked PR (search `gh pr list --search "Fixes #<num>"`
+or check the issue's timeline), relabel to `auto-improve:pr-open` and update
+the `## Related` section with the PR link.
+
+### `pr-open` → `merged`
+If the linked PR's state is `MERGED`, relabel to `auto-improve:merged`, set
+`Verification streak: 0`, and add a comment:
+`Fix PR merged in <sha>. Entering verification window (need VERIFY_RUNS=<N> clean runs).`
+
+### `merged` → `solved` (close)
+If the issue is in `merged` state **and** the problem did **not** appear in
+this run's evidence (i.e. it was not matched as a regression in Step 4), bump
+its `Verification streak` by 1.
+
+When `Verification streak >= VERIFY_RUNS`, close the issue:
+
+```bash
+gh issue edit <num> --remove-label auto-improve:merged --add-label auto-improve:solved
+gh issue close <num> --comment "Verified solved: <N> successive clean runs since fix merged."
+```
+
+### `merged` regression
+Handled in Step 4 — do nothing extra here.
+
+---
+
+## Step 6 — Ship fixes as focused PRs
+
+For each issue currently in state `raised` that you can fix automatically with
+a small, targeted code change:
+
+1. `git checkout main && git pull`
+2. Create a branch: `auto-improve/<date>-<fingerprint-key>`
+3. Make the **actual** edits (no `proposals/` directory). Keep it ≤ 5 files.
+4. Commit with a clear "why" message.
+5. Push and open a PR:
+   - **Title**: concise imperative prefix (`fix:`, `feat:`, `chore:`).
+   - **Body** required sections: `## Problem`, `## Change`, `## Files`,
+     `## Evidence`, and a final line `Fixes #<issue-num>`.
+6. After the PR opens, update the corresponding issue:
+   - Append PR link to `## Related`.
+   - Relabel: remove `auto-improve:raised`, add `auto-improve:pr-open`.
+
+If an issue cannot be fixed automatically (requires human judgment, external
+access, or is purely advisory), leave it in `raised` state. Add a comment on
+it explaining why it wasn't auto-fixed.
+
+Cap yourself at **5 new PRs per run** — if more than 5 `raised` issues are
+auto-fixable, ship the 5 highest-impact ones and leave the rest.
+
+---
+
+## Step 7 — Run summary (stdout only, not an issue)
+
+Print a final summary to stdout:
+
+```
+============================================
+  Auto-improvement tracker run summary
+  Date:                    <YYYY-MM-DD>
+  Workflows parsed:        <N>
+  Conversations analyzed:  <N> / CONVERSATION_LIMIT
+  New issues created:      <N>
+  Existing issues updated: <N>
+  Issues advanced raised→pr-open:    <N>
+  Issues advanced pr-open→merged:    <N>
+  Issues advanced merged→solved:     <N>
+  Regressions detected:    <N>
+  PRs opened:              <N>
+============================================
+```
+
+No umbrella issue. The summary lives only in the workflow run log. Humans can
+read the full state by filtering issues by the `auto-improve` label.
+
+---
+
+## Guardrails
+
+- Before editing an issue, always re-read its current body — another run or a
+  human may have modified it. Preserve any manual edits; only update the
+  structured sections you own.
+- Never create a new issue if a semantically matching open or recently-closed
+  one exists. When in doubt, update the existing one.
+- Never force-push. Never rewrite `main`. Each fix PR targets `main` from its
+  own branch.
 - Never modify `.env`, `*.key`, `*.pem`, or `credentials.*`.
 - **Do not try to push changes under `.github/workflows/`.** The GitHub App
   token this agent runs under does **not** have the `workflows` permission,
@@ -222,10 +320,9 @@ links go both ways.
   `.github/workflows/<file>.yml` without `workflows` permission
   ```
 
-  If an improvement subject would require a workflow change, list it in the
-  umbrella issue under **Recommendations (no PR)** with a concrete diff the
-  human maintainer can apply, instead of opening a PR that cannot merge.
-- Never force-push. Never rewrite `main`. Each PR targets `main` from its own
-  branch.
-- If a PR would touch more than ~5 files, reconsider whether it's really one
-  subject — split it or narrow the scope.
+  If an improvement subject requires a workflow change, **still raise (or
+  update) the tracked issue** for it, but do not open a PR. Instead, add a
+  comment on the issue containing a concrete diff the human maintainer can
+  apply, and leave the issue in `auto-improve:raised` state.
+- If `WORKFLOWS_PARSED` and `CONVERSATIONS_ANALYZED` are both 0, exit without
+  modifying any issues or opening any PRs.


### PR DESCRIPTION
## Problem
The previous auto-improvement flow produced a one-shot umbrella issue plus a batch of PRs per run, with no memory between runs. That meant:
- Recurring problems got rediscovered and re-filed every week as brand-new issues.
- There was no way to confirm whether a merged fix actually solved the underlying problem.
- No long-term record of which improvement subjects were active, fixed, or regressed.

## Change
Replace the umbrella model with a **persistent issue tracker**. Each recurring problem is represented by exactly one GitHub issue that moves through a lifecycle:

```
raised  →  pr-open  →  merged  →  solved (closed)
```

State is encoded in labels (`auto-improve:raised`, `:pr-open`, `:merged`, `:solved`) plus a machine-readable fingerprint block (`<!-- auto-improve:fingerprint key: ... category: ... -->`) embedded in the issue body.

On every run the tracker:
1. Discovers problems from workflow logs (unlimited) + Claude Code transcripts (capped at `CONVERSATION_LIMIT`).
2. Requires ≥2 observations or 1 high-confidence observation before raising.
3. Dedupes new candidates against all existing auto-improve issues — first by fingerprint key, then by semantic match. Matched candidates update the existing issue in place (bump occurrence counter, append evidence). Closed `solved` issues that match reopen as regressions.
4. Advances lifecycle state for all open auto-improve issues: detects linked PRs, detects merges, bumps the verification streak on clean runs, and closes an issue as `solved` after `VERIFY_RUNS` (default 2) successive clean runs.
5. Ships focused fix PRs (max 5/run) that reference their issue via `Fixes #<num>`.

No umbrella issue. The per-run summary lives only in stdout; humans read long-term state by filtering by the `auto-improve` label.

## Files
- `scripts/auto-improve-prompt.md` — full rewrite: lifecycle contract, fingerprint scheme, reconciliation algorithm, state-advancement rules, guardrails.
- `.github/workflows/auto-improve.yml` — rename job to "Auto-Improvement Tracker", add `gh label:*` and `jq:*` tools, resolve `VERIFY_RUNS` from config, update inline prompt to point at the new flow.
- `auto_tune_config.yml` — add `tracking.verify_runs` (default 2).

## Test plan
- [ ] Trigger manually with `conversation_limit=5` on a clean repo and confirm: labels are auto-created; new issues carry a fingerprint block; PRs reference their issue via `Fixes #<num>`.
- [ ] Trigger a second run with no new problems and confirm a merged issue's verification streak bumps to 1.
- [ ] Trigger a third run and confirm the issue closes as `auto-improve:solved`.
- [ ] Introduce a regression after a solved close and confirm the issue reopens as `raised` with a regression comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)