### PR TITLE
docs: add docs/ folder for GitHub Pages and slim README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,34 @@
 # Claude Auto Tune
 
-A self-improving Claude Code workspace. Run Claude locally in Docker for safe autonomous operation, or through CI via the official `anthropics/claude-code-action@v1` GitHub Action.
+A self-improving [Claude Code](https://claude.com/claude-code) workspace. Run Claude locally in Docker for safe autonomous operation, or through CI via the official `anthropics/claude-code-action@v1` GitHub Action.
 
 ## Quick start
 
-### Local (Docker)
+Local (Docker):
 
 ```bash
 ./run.sh
 ```
 
-This builds and runs Claude in a Docker container with `--dangerously-skip-permissions` for autonomous operation. Auth state persists in `.claude-home/`.
-
-### CI (GitHub Actions)
-
-First, authenticate with GitHub (with the required scopes):
+CI (GitHub Actions):
 
 ```bash
 gh auth login -h github.com -s repo,workflow
-```
-
-Then, from inside Claude Code CLI:
-
-```
+# then, inside Claude Code CLI:
 /install-github-app
 ```
 
-This installs the Claude GitHub App and configures the `ANTHROPIC_API_KEY` secret. Then mention `@claude` in any issue or PR comment.
+Then mention `@claude` in any issue or PR comment.
 
-## Structure
+## Documentation
 
-```
-.claude/settings.json   # Shared Claude settings (tracked in git)
-CLAUDE.md               # Agent instructions
-Dockerfile              # Container for local runs
-docker-compose.yml      # Docker orchestration
-run.sh                  # Entry point for local sessions
-```
+Full documentation is published to GitHub Pages:
+
+**https://damien-robotsix.github.io/claude_auto_tune/**
+
+Source lives in [`docs/`](docs/):
+
+- [Quick start](docs/quickstart.md)
+- [Configuration](docs/configuration.md)
+- [Workflows](docs/workflows.md)
+- [Architecture](docs/architecture.md)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,4 @@
+title: Claude Auto Tune
+description: A self-improving Claude Code workspace
+theme: jekyll-theme-cayman
+show_downloads: false

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,40 @@
+---
+title: Architecture
+layout: default
+---
+
+# Architecture
+
+The workspace is intentionally small. Everything you need to understand it fits in a handful of files.
+
+## Repo layout
+
+```
+.claude/settings.json     # Shared Claude Code settings (tracked in git)
+.github/workflows/        # CI workflows: claude, claude-code-review, auto-improve
+CLAUDE.md                 # Agent instructions read by Claude Code
+Dockerfile                # Container image used for local runs
+docker-compose.yml        # Build/orchestration for the local image
+run.sh                    # Entry point for local sessions
+auto_tune_config.yml      # Workspace configuration (models, auto-improve, log parser)
+scripts/                  # Log/transcript parsing + auto-improve prompt
+docs/                     # This documentation, published to GitHub Pages
+```
+
+## Local vs CI
+
+- **Local** runs go through `run.sh` → `docker compose build` → `docker run` with the repo mounted at `/workspace` and `.claude-home/` providing persistent Claude/`gh` state.
+- **CI** runs go through `.github/workflows/*.yml`, which call `anthropics/claude-code-action@v1` with the API key from the `ANTHROPIC_API_KEY` secret.
+
+Both paths share the same `CLAUDE.md`, `.claude/settings.json`, and `auto_tune_config.yml`, so behaviour stays consistent.
+
+## Self-improvement loop
+
+The `auto-improve` workflow is what makes this a *self-tuning* workspace:
+
+1. Collect recent run history (logs, transcripts).
+2. Compact it through the `scripts/parse-*.py` helpers, bounded by `log_parser` limits.
+3. Feed the result into Claude with `scripts/auto-improve-prompt.md`.
+4. Open PRs that tweak prompts, configuration, or tooling based on what was learned.
+
+Keeping the loop narrow and the surface area small is deliberate: it makes each improvement easy to review and easy to revert.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,60 @@
+---
+title: Configuration
+layout: default
+---
+
+# Configuration
+
+Most workspace-level tuning lives in [`auto_tune_config.yml`](https://github.com/damien-robotsix/claude_auto_tune/blob/main/auto_tune_config.yml) at the repo root. Workflows and scripts read it to decide which model to use and how the auto-improve loop behaves.
+
+## Models
+
+The `models` section assigns a model family to each entry point:
+
+```yaml
+models:
+  claude_code: "opus"   # main claude.yml workflow
+  code_review: "opus"   # code-review workflow
+  auto_improve: "opus"  # auto-improve workflow
+  log_parser: "haiku"   # log/transcript parsing scripts (cheaper, fast)
+```
+
+You can use a short alias (`haiku`, `sonnet`, `opus`) or pin a full model ID (for example `claude-sonnet-4-6`).
+
+## Model aliases
+
+The `model_aliases` section maps short names to specific model IDs. Update this section when new model versions are released:
+
+```yaml
+model_aliases:
+  haiku:  "claude-haiku-4-5-20251001"
+  sonnet: "claude-sonnet-4-6"
+  opus:   "claude-opus-4-6"
+```
+
+Scripts fall back to built-in defaults if this section is missing.
+
+## Auto-improve loop
+
+```yaml
+auto_improve:
+  default_run_count: 20
+  schedule: "0 3 * * 0"
+```
+
+- `default_run_count` — how many past runs the auto-improve workflow considers in a single pass.
+- `schedule` — cron expression (UTC) used by the scheduled workflow trigger.
+
+## Log parser limits
+
+```yaml
+log_parser:
+  max_log_chars: 40000
+  max_summary_chars: 30000
+```
+
+These bound the size of raw logs and generated summaries so that parsing stays within sensible token budgets.
+
+## Claude settings
+
+Per-workspace Claude Code settings (tools, permissions, etc.) live in [`.claude/settings.json`](https://github.com/damien-robotsix/claude_auto_tune/blob/main/.claude/settings.json) and are tracked in git so they apply to every contributor and CI run.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,21 @@
+---
+title: Claude Auto Tune
+layout: default
+---
+
+# Claude Auto Tune
+
+A self-improving [Claude Code](https://claude.com/claude-code) workspace. Run Claude locally in Docker for safe autonomous operation, or through CI via the official `anthropics/claude-code-action@v1` GitHub Action.
+
+The workspace is designed to grow incrementally — start simple, add tooling as patterns emerge — and to periodically tune its own configuration, prompts, and scripts based on accumulated run history.
+
+## Documentation
+
+- [Quick start](quickstart.md) — run Claude locally or wire it into CI.
+- [Configuration](configuration.md) — `auto_tune_config.yml`, model aliases, and workspace settings.
+- [Workflows](workflows.md) — the CI workflows (`claude`, `claude-code-review`, `auto-improve`) and what each does.
+- [Architecture](architecture.md) — repo layout and how the pieces fit together.
+
+## Source
+
+The project lives at [damien-robotsix/claude_auto_tune](https://github.com/damien-robotsix/claude_auto_tune).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,50 @@
+---
+title: Quick start
+layout: default
+---
+
+# Quick start
+
+There are two ways to use this workspace: locally through Docker, or in CI via the Claude GitHub App.
+
+## Local (Docker)
+
+```bash
+./run.sh
+```
+
+This builds and runs Claude in a Docker container with `--dangerously-skip-permissions` for autonomous operation. Auth state persists in `.claude-home/` on the host, so you only need to authenticate once.
+
+What `run.sh` does:
+
+1. Builds the `claude_auto_tune-claude` image from the repo `Dockerfile` (via `docker compose build`).
+2. Ensures the host-side bind-mount directories exist under `.claude-home/`.
+3. Runs the container interactively with the workspace mounted at `/workspace`.
+
+You can pass extra flags straight through to the Claude CLI:
+
+```bash
+./run.sh --help
+```
+
+## CI (GitHub Actions)
+
+First, authenticate with GitHub using the required scopes:
+
+```bash
+gh auth login -h github.com -s repo,workflow
+```
+
+Then, from inside the Claude Code CLI:
+
+```
+/install-github-app
+```
+
+This installs the Claude GitHub App and configures the `ANTHROPIC_API_KEY` secret in the repo. Once installed, mention `@claude` in any issue or PR comment to trigger a run.
+
+## Requirements
+
+- Docker (for local runs)
+- `gh` CLI (for the GitHub App setup step)
+- A valid Anthropic API key, stored as the `ANTHROPIC_API_KEY` repo secret for CI runs

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,34 @@
+---
+title: Workflows
+layout: default
+---
+
+# Workflows
+
+The repo ships three GitHub Actions workflows under `.github/workflows/`. All of them read model assignments from [`auto_tune_config.yml`](configuration.md).
+
+## `claude.yml` — interactive agent
+
+Triggered when `@claude` is mentioned in an issue or PR comment, or when an issue is assigned/labelled accordingly. Runs the `anthropics/claude-code-action@v1` action with the model configured as `models.claude_code`.
+
+Use it to ask Claude to answer questions, review changes, or implement small-to-medium tasks directly from GitHub.
+
+## `claude-code-review.yml` — automated review
+
+Runs on pull requests and asks Claude (using `models.code_review`) to review the diff. The review focuses on correctness, readability, and security, as laid out in [`CLAUDE.md`](https://github.com/damien-robotsix/claude_auto_tune/blob/main/CLAUDE.md).
+
+## `auto-improve.yml` — self-tuning loop
+
+Runs on the cron schedule defined in `auto_improve.schedule` (and can be dispatched manually). It inspects recent runs, parses logs via the scripts in `scripts/`, and proposes improvements to prompts, configuration, or tooling.
+
+The goal is to let the workspace grow incrementally: when a pattern of failure or friction repeats, the loop captures the lesson rather than repeating the mistake.
+
+## Scripts
+
+Supporting scripts live in [`scripts/`](https://github.com/damien-robotsix/claude_auto_tune/tree/main/scripts):
+
+- `auto-improve-prompt.md` — the prompt used by the auto-improve workflow.
+- `parse-claude-transcript.py` — parses Claude transcripts into a compact summary.
+- `parse-workflow-log.py` — parses raw workflow logs into a compact summary.
+
+Both parsing scripts honour the `log_parser` limits from `auto_tune_config.yml`.


### PR DESCRIPTION
Moves long-form documentation into a `docs/` folder structured for GitHub Pages (Jekyll with `jekyll-theme-cayman`), and slims `README.md` down to a short description, minimal quickstart, and a link to the published docs.

### Contents

- `docs/_config.yml` — Jekyll site config
- `docs/index.md` — landing page
- `docs/quickstart.md` — local Docker + CI setup
- `docs/configuration.md` — `auto_tune_config.yml`, models, aliases, auto-improve, log parser
- `docs/workflows.md` — the three CI workflows and scripts
- `docs/architecture.md` — repo layout and self-improvement loop

### Manual step

Enable GitHub Pages in repo settings: Source = `Deploy from a branch`, Branch = `main`, Folder = `/docs`.

Resolves #14

Generated with [Claude Code](https://claude.ai/code)