### PR TITLE
Remove unused log_parser config parameters

### DIFF
--- a/auto_tune_config.yml
+++ b/auto_tune_config.yml
@@ -27,7 +27,3 @@ auto_improve:
   # are always analyzed in full (no cap).
   default_conversation_limit: 20
   schedule: "0 3 * * 0"
-
-log_parser:
-  max_log_chars: 40000
-  max_summary_chars: 30000

--- a/scripts/parse-claude-transcript.py
+++ b/scripts/parse-claude-transcript.py
@@ -70,7 +70,6 @@ def _load_config() -> dict:
 
 
 _CONFIG = _load_config()
-_LOG_PARSER_CFG = _CONFIG.get("log_parser", {})
 
 
 def _resolve_model(name: str) -> str:
@@ -121,9 +120,6 @@ Session tool-call summary:
 ---
 {transcript_summary}
 ---"""
-
-MAX_SUMMARY_CHARS = int(_LOG_PARSER_CFG.get("max_summary_chars", 30_000))
-
 
 def extract_tool_calls(lines: list[str]) -> dict:
     """Parse JSONL transcript lines and extract tool call statistics."""
@@ -226,9 +222,6 @@ def extract_tool_calls(lines: list[str]) -> dict:
 
 def parse_transcript(summary_text: str) -> dict:
     client = _build_anthropic_client()
-
-    if len(summary_text) > MAX_SUMMARY_CHARS:
-        summary_text = summary_text[:MAX_SUMMARY_CHARS] + "\n\n... [truncated] ..."
 
     prompt = EXTRACT_PROMPT.format(transcript_summary=summary_text)
 

--- a/scripts/parse-workflow-log.py
+++ b/scripts/parse-workflow-log.py
@@ -66,7 +66,6 @@ def _load_config() -> dict:
 
 
 _CONFIG = _load_config()
-_LOG_PARSER_CFG = _CONFIG.get("log_parser", {})
 
 
 def _resolve_model(name: str) -> str:
@@ -115,27 +114,10 @@ Log:
 {log_content}
 ---"""
 
-# Truncate logs to avoid token limits — Haiku context window is 200k but we
-# keep it lean to stay cheap. Middle sections of logs tend to be noise.
-MAX_LOG_CHARS = int(_LOG_PARSER_CFG.get("max_log_chars", 40_000))
-
-
-def truncate_log(log: str) -> str:
-    if len(log) <= MAX_LOG_CHARS:
-        return log
-    half = MAX_LOG_CHARS // 2
-    return (
-        log[:half]
-        + f"\n\n... [truncated {len(log) - MAX_LOG_CHARS} chars] ...\n\n"
-        + log[-half:]
-    )
-
-
 def parse_log(log_content: str) -> dict:
     client = _build_anthropic_client()
 
-    truncated = truncate_log(log_content)
-    prompt = EXTRACT_PROMPT.format(log_content=truncated)
+    prompt = EXTRACT_PROMPT.format(log_content=log_content)
 
     _alias = _CONFIG.get("models", {}).get("log_parser", "haiku")
     message = client.messages.create(


### PR DESCRIPTION
Removes `log_parser.max_log_chars` and `log_parser.max_summary_chars` from `auto_tune_config.yml` and deletes the associated truncation logic from the two parser scripts.

- `max_summary_chars` was dead code: the synthesized tool-call summary is bounded by construction and never reached 30k chars.
- `max_log_chars` at 40k was actively harmful: it dropped the middle of every non-trivial workflow log, hiding the errors and retries the parser is supposed to surface. Haiku's 200k context easily fits full logs.

Closes #15.

Generated with [Claude Code](https://claude.ai/code)