### PR TITLE
feat: daily docs-sync workflow

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -1,0 +1,93 @@
+name: Docs Sync
+
+on:
+  schedule:
+    # Runs every day at 06:00 UTC, after the usual push window.
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      since:
+        description: "Git --since window (e.g. '24 hours ago', '3 days ago')"
+        required: false
+        default: '24 hours ago'
+
+jobs:
+  docs-sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Need enough history to look back through the window.
+          fetch-depth: 0
+
+      - name: Collect doc-relevant diff
+        id: collect
+        run: |
+          bash scripts/collect-doc-relevant-diff.sh "${{ github.event.inputs.since || '24 hours ago' }}"
+          if [ -s .scratch/doc-diff.txt ]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve model from auto_tune_config.yml
+        if: steps.collect.outputs.has_changes == 'true'
+        id: model
+        run: |
+          alias=$(yq '.models.docs_sync // .models.auto_improve // "sonnet"' auto_tune_config.yml)
+          id=$(yq ".model_aliases.\"$alias\" // \"$alias\"" auto_tune_config.yml)
+          echo "id=$id" >> "$GITHUB_OUTPUT"
+
+      - name: Run Docs Sync Agent
+        if: steps.collect.outputs.has_changes == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          prompt: |
+            Read `scripts/docs-sync-prompt.md` — it contains your full
+            instructions. You are the daily docs-sync agent. Your job is
+            narrow: keep pages under `docs/` aligned with whatever landed
+            on `main` in the last window. You do not propose code changes
+            or touch anything outside `docs/`.
+
+            The change set has already been collected for you:
+              .scratch/doc-commits.txt — commits in the window
+              .scratch/doc-diff.txt    — unified diff (docs/ and .github/ excluded)
+
+            Routing map: docs/.docsrules
+
+            Today's date: $(date +%Y-%m-%d)
+
+            If nothing meaningful changed, exit without opening a PR.
+
+          claude_args: >-
+            --model ${{ steps.model.outputs.id }}
+            --allowed-tools
+            Bash(git *),
+            Bash(gh pr:*),
+            Bash(cat *),
+            Bash(ls *),
+            Bash(wc *),
+            Bash(head *),
+            Bash(find *),
+            Read,
+            Write,
+            Edit,
+            Glob,
+            Grep
+
+      - name: Upload Claude session transcript
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-transcript
+          path: ~/.claude/projects/**/*.jsonl
+          if-no-files-found: ignore
+          retention-days: 30

--- a/docs/.docsrules
+++ b/docs/.docsrules
@@ -1,0 +1,38 @@
+# docs/.docsrules
+#
+# Mapping from source paths (globs) to the documentation page that most
+# likely needs updating when files matching the glob change.
+#
+# Format: one rule per non-comment line.
+#   <source-pathspec>  ->  <target-doc-file>
+#
+# The docs-sync agent reads this file first and uses it to route
+# change-set entries to specific doc pages. A single source file may
+# match multiple rules; all matching targets are candidates.
+#
+# Pathspecs are plain shell globs, rooted at the repo root. Use `**` for
+# recursive matches. Use the literal string `(skip)` on the right-hand
+# side to mark changes that should not drive a docs update.
+
+# Workflows — user-visible behavior of the agent pipeline
+.github/workflows/*.yml                 -> docs/workflows.md
+
+# Config — every user-visible knob
+auto_tune_config.yml                    -> docs/configuration.md
+scripts/parse-workflow-log.py           -> docs/configuration.md
+scripts/parse-claude-transcript.py      -> docs/configuration.md
+
+# Architecture — pipeline prompts, agent shape, CLAUDE.md conventions
+scripts/auto-improve-prompt.md          -> docs/architecture.md
+scripts/docs-sync-prompt.md             -> docs/architecture.md
+CLAUDE.md                               -> docs/architecture.md
+
+# Quickstart — top-level onboarding surface
+README.md                               -> docs/quickstart.md
+
+# CI sandbox rules mirror a single source file; drift is unlikely to
+# come from unrelated code changes.
+docs/ci-sandbox-rules.md                -> (skip)
+
+# The agent's own outputs never drive further updates.
+docs/**                                 -> (skip)

--- a/scripts/collect-doc-relevant-diff.sh
+++ b/scripts/collect-doc-relevant-diff.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# collect-doc-relevant-diff.sh
+#
+# Emit the commit list and unified diff for changes on the current branch
+# since a cutoff (default: 24 hours ago), excluding paths that should not
+# drive docs updates (docs/ itself, lockfiles, CI configs, etc.).
+#
+# Output goes to two files under .scratch/ inside the repo:
+#   .scratch/doc-commits.txt  — one `git log` line per commit in window
+#   .scratch/doc-diff.txt     — unified diff with excluded paths stripped
+#
+# Exit status:
+#   0 — always (emptiness is checked by the caller, not via exit code).
+#
+# Usage:
+#   scripts/collect-doc-relevant-diff.sh                # default: 24 hours
+#   scripts/collect-doc-relevant-diff.sh "48 hours ago" # custom window
+
+set -euo pipefail
+
+SINCE="${1:-24 hours ago}"
+OUT_DIR=".scratch"
+mkdir -p "$OUT_DIR"
+
+COMMITS_FILE="$OUT_DIR/doc-commits.txt"
+DIFF_FILE="$OUT_DIR/doc-diff.txt"
+: > "$COMMITS_FILE"
+: > "$DIFF_FILE"
+
+# Find the oldest commit on HEAD whose author date is within the window.
+# If none, there's nothing to report.
+BASE=$(git log --since="$SINCE" --reverse --format=%H HEAD | head -n 1 || true)
+
+if [ -z "$BASE" ]; then
+  echo "No commits on HEAD since '$SINCE'."
+  echo ">>> Window commits: 0"
+  exit 0
+fi
+
+# Determine the diff range. Use the parent of the oldest in-window commit as
+# the base. If BASE is the repository root (no parent), fall back to the
+# empty tree.
+if git rev-parse --verify --quiet "${BASE}^" >/dev/null; then
+  RANGE_BASE="${BASE}^"
+else
+  RANGE_BASE=$(git hash-object -t tree /dev/null)  # empty tree SHA
+fi
+
+# Commit list (one line per commit, oldest-first).
+git log --reverse --format='%h  %ci  %s' "${RANGE_BASE}..HEAD" > "$COMMITS_FILE"
+
+# Exclusion pathspecs. Keep this list narrow — only exclude things that
+# demonstrably should not drive a docs update.
+EXCLUDES=(
+  ':!docs/**'                 # the agent's own output target
+  ':!.github/**'              # workflow edits cannot be pushed by the agent anyway
+  ':!**/*.lock'
+  ':!**/*.lockb'
+  ':!**/package-lock.json'
+  ':!**/pnpm-lock.yaml'
+  ':!**/yarn.lock'
+  ':!**/Cargo.lock'
+  ':!**/poetry.lock'
+  ':!**/uv.lock'
+  ':!.gitignore'
+)
+
+git diff "${RANGE_BASE}..HEAD" -- . "${EXCLUDES[@]}" > "$DIFF_FILE"
+
+COMMIT_COUNT=$(wc -l < "$COMMITS_FILE" | tr -d ' ')
+DIFF_BYTES=$(wc -c < "$DIFF_FILE" | tr -d ' ')
+echo ">>> Window commits: $COMMIT_COUNT"
+echo ">>> Diff bytes (post-exclude): $DIFF_BYTES"
+echo ">>> Commits file: $COMMITS_FILE"
+echo ">>> Diff file:    $DIFF_FILE"

--- a/scripts/docs-sync-prompt.md
+++ b/scripts/docs-sync-prompt.md
@@ -1,0 +1,114 @@
+# Docs-Sync Agent Prompt
+
+You are the daily docs-sync agent for this Claude Code workspace. Your job is
+narrow: keep pages under `docs/` aligned with whatever landed on `main` in the
+last 24 hours. You are **not** an auto-improvement agent — you do not propose
+code changes, refactors, or workflow fixes. You only edit `docs/`.
+
+## Inputs
+
+Two scratch files have already been written for you in the working directory:
+
+- `.scratch/doc-commits.txt` — one line per commit in the window
+  (format: `<shortsha>  <iso-date>  <subject>`).
+- `.scratch/doc-diff.txt` — unified diff for the same window, with `docs/`,
+  `.github/`, and lockfiles already excluded. This is what you react to.
+
+Also required reading:
+
+- `docs/.docsrules` — mapping from source path globs to the likely target
+  doc page. Load this first; it's how you route changes to the right page.
+
+## Step 1 — Decide if there is anything to do
+
+Read `.scratch/doc-commits.txt` and `.scratch/doc-diff.txt`.
+
+- If the diff file is empty or contains only whitespace, **exit without any
+  edits, commits, or PRs**. Print `docs-sync: no relevant changes` and stop.
+- If the diff only reformats existing code (whitespace, import reordering,
+  rename of an internal symbol with no user-visible effect), also exit. Docs
+  should reflect *user-visible* behavior, not internal churn.
+
+## Step 2 — Route changes to doc pages via .docsrules
+
+For each changed source file in the diff, consult `docs/.docsrules` to find
+the target doc page(s). Build a mapping:
+
+```
+<source-file> → <candidate-doc-page(s)>
+```
+
+Files with target `(skip)` are excluded. Files that match no rule get a
+single candidate: `docs/architecture.md` (as the general catch-all), but
+only if the change is clearly user-visible.
+
+## Step 3 — For each candidate doc page, read and assess
+
+Open each candidate page with the `Read` tool. For each:
+
+1. Identify the sections that describe the subject matter touched by the
+   diff.
+2. Decide: is the current text **still accurate** after the change?
+3. If accurate → leave it alone. Do not "improve" wording, reflow paragraphs,
+   or update unrelated sections. **Minimal edits only.**
+4. If inaccurate → update exactly the outdated sentences/code blocks. Match
+   the surrounding tone and level of detail. Do not rewrite sections that
+   were not affected.
+5. If a new concept was introduced (new config key, new script, new workflow
+   behavior) and no section currently covers it → add a short subsection in
+   the most relevant place. A few sentences plus a code example is usually
+   enough; this is not a spec.
+
+### Hard rules
+
+- **Do not touch `README.md`** unless the diff broke the quickstart steps
+  it documents.
+- **Preserve frontmatter** (the `---` block at the top of doc pages) exactly.
+- **Preserve the Jekyll-style `_config.yml`** — it is configuration, not
+  documentation.
+- **Never invent** CLI flags, config keys, file paths, or behaviors that
+  aren't in the diff. If you are not sure what a change does, add a
+  `<!-- TODO(docs-sync): verify <thing> -->` HTML comment in place of a
+  guess.
+- **Never delete a doc page** as part of this workflow.
+- Do not touch `docs/.docsrules` itself — that's a human-maintained file.
+
+## Step 4 — If no edits were needed, exit quietly
+
+If after reading all candidates you concluded nothing needs updating, print
+`docs-sync: no edits required` and stop. Do not create a branch, do not
+commit, do not open a PR.
+
+## Step 5 — If edits were made, ship them as a PR
+
+1. `git checkout -b docs-sync/<YYYY-MM-DD>`
+2. `git add docs/`
+3. `git commit -m "docs: daily sync <YYYY-MM-DD>"` with a body that lists
+   each touched page and a one-line reason, e.g.
+   ```
+   - docs/configuration.md — new `tracking.verify_runs` key added in <sha>
+   - docs/workflows.md     — auto-improve cadence changed in <sha>
+   ```
+4. `git push -u origin docs-sync/<YYYY-MM-DD>`
+5. Open the PR:
+   ```bash
+   gh pr create \
+     --title "docs: daily sync <YYYY-MM-DD>" \
+     --body-file .scratch/docs-sync-pr-body.md
+   ```
+   The body should summarize:
+   - Which commits in the window triggered the update.
+   - Which doc pages were modified and why (one bullet per page).
+   - Any `TODO(docs-sync)` comments you left for human review.
+
+## Guardrails
+
+- Never force-push. Never rewrite `main`. The PR targets `main` from its own
+  branch.
+- Do not touch anything outside `docs/`.
+- If the diff contains security-sensitive changes (secrets, auth flows,
+  permissions), still update the docs, but add a line in the PR body
+  flagging the area for extra human attention.
+- If `.scratch/doc-diff.txt` is larger than ~200 KB, something is wrong
+  (probably a mass rename). Print a warning and exit without edits — this
+  is not the pass that should handle that.


### PR DESCRIPTION
## Summary
Adds a lightweight scheduled loop that keeps `docs/` aligned with whatever landed on `main` in the last 24h. Minimal MVP per the agreed scope: just the workflow, helper script, prompt, and routing map — no changelog page, no PR-time drift warning (those can follow once we see whether the daily loop actually produces useful PRs).

## How it works
1. **Cron** — `0 6 * * *` daily, or `workflow_dispatch` with a custom `--since` window.
2. **Diff gathering** — `scripts/collect-doc-relevant-diff.sh` computes the commit list and unified diff over the window, excluding `docs/`, `.github/`, and lockfiles. Writes to `.scratch/doc-commits.txt` and `.scratch/doc-diff.txt` inside the working directory (sandbox-friendly).
3. **Early exit** — the workflow checks `.scratch/doc-diff.txt`; if empty, the Claude step is skipped entirely. Saves tokens on quiet days.
4. **Claude pass** — reads the prompt file, `docs/.docsrules`, and the collected diff. For each doc page touched by the change set, it decides whether the current text is still accurate and edits only the outdated sentences/code blocks. Hard rules: never touch `README.md` unless the quickstart broke, preserve frontmatter, use `<!-- TODO(docs-sync): ... -->` comments instead of guessing.
5. **PR, not direct commit** — the agent opens `docs: daily sync YYYY-MM-DD` against `main`. A human skims and merges. If nothing needs updating, the agent exits without opening a PR.

## Files
- `.github/workflows/docs-sync.yml` — scheduled workflow.
- `scripts/collect-doc-relevant-diff.sh` — range-diff helper. Handles the root-commit edge case via the empty-tree SHA. Smoke-tested locally over a 7-day window on this repo (38 commits, ~33 KB of diff after exclusions).
- `scripts/docs-sync-prompt.md` — agent instructions: routing, minimal-edit discipline, guardrails.
- `docs/.docsrules` — source-path → doc-page routing map.

## Model resolution
The workflow prefers a new optional `models.docs_sync` key in `auto_tune_config.yml` and falls back to `models.auto_improve` then `"sonnet"`, so no config change is required to run this.

## Test plan
- [ ] Trigger manually via `workflow_dispatch` with `since="7 days ago"` and confirm the agent either opens a `docs: daily sync` PR or exits quietly with `no edits required`.
- [ ] Confirm the early-exit step skips the Claude agent entirely when the diff file is empty.
- [ ] After the first real daily run, review the PR's edits for quality and either tighten the prompt or add more rules to `docs/.docsrules` based on what you see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)