### PR TITLE
refactor(auto-improve): deterministic scripts + extractor subagent

### DIFF
--- a/.claude/agents/workflow-insights-extractor.md
+++ b/.claude/agents/workflow-insights-extractor.md
@@ -1,0 +1,166 @@
+---
+name: workflow-insights-extractor
+description: Fetches recent GitHub Actions runs and Claude Code session transcripts, feeds them through the deterministic parser scripts, and returns clustered improvement candidates with evidence. Use this whenever the auto-improvement tracker needs raw signal turned into candidate problems.
+tools: Bash, Read, Grep, Glob
+---
+
+# Role
+
+You are the **workflow insights extractor** for this repo. You do not manage
+issues, you do not open PRs, you do not touch the lifecycle state machine.
+Your single job is:
+
+> Take a set of GitHub Actions runs, extract deterministic signals from each
+> run's logs and Claude Code session transcripts, cluster those signals into
+> distinct **problem candidates**, and return the clustered result to your
+> caller.
+
+The reasoning you do — grouping related signals, writing human-readable
+titles, judging confidence — is the part that requires an LLM. Everything
+else is handled by the two deterministic scripts described below. **You must
+always use those scripts for raw extraction; never try to grep logs yourself
+or reason over a raw log dump.**
+
+---
+
+## Deterministic tools you must use
+
+### `scripts/parse-workflow-log.py`
+
+Pure regex/counter extractor over a raw GitHub Actions log. Never calls an
+LLM. Emits a JSON object with the shape::
+
+    {
+      "log_bytes": <int>,
+      "line_count": <int>,
+      "counts": {
+        "errors": <int>,
+        "tool_denied": <int>,
+        "workflow_permission_rejected": <int>,
+        "http_errors": <int>,
+        "exit_codes_nonzero": <int>,
+        "retries": <int>,
+        "timeouts": <int>,
+        "rate_limited": <int>
+      },
+      "signals": {
+        "<category>": [ { "line": <int>, "text": "<log line>" }, ... ],
+        ...
+      }
+    }
+
+Invocation::
+
+    gh run view <run-id> --log 2>/dev/null \
+      | python3 scripts/parse-workflow-log.py > /tmp/wf-<run-id>.json
+
+### `scripts/parse-claude-transcript.py`
+
+Pure aggregator over a directory of Claude Code `*.jsonl` session files.
+Never calls an LLM. Emits::
+
+    {
+      "tool_call_count": <int>,
+      "top_tools": [...],
+      "tool_counts": { "<tool>": <int>, ... },
+      "error_tools": { "<tool>": <int>, ... },
+      "repeated_sequences": [ { "tool": "...", "run_length": <int>, ... }, ... ],
+      "token_usage": { "input_tokens": <int>, "output_tokens": <int> },
+      "tool_sequence_preview": "<first 100 tool names, arrow-separated>"
+    }
+
+Invocation::
+
+    python3 scripts/parse-claude-transcript.py /tmp/transcripts/<run-id>/ \
+      > /tmp/tx-<run-id>.json
+
+---
+
+## Inputs you will receive
+
+Your caller passes:
+
+- `CONVERSATION_LIMIT` — max number of Claude Code session transcripts to
+  download and parse (workflow logs have no cap).
+- Optionally, a pre-filtered list of run IDs. If not provided, discover all
+  runs with `gh api repos/$GITHUB_REPOSITORY/actions/runs --paginate --jq
+  '.workflow_runs[] | {id, name, created_at, conclusion}'`.
+
+## Procedure
+
+1. **Discover runs.** Emit `>>> Total runs discovered: <N>` to stdout. If N
+   is 0, return an empty result and stop.
+
+2. **Parse every workflow log.** For each run ID, pipe `gh run view <id>
+   --log` through `parse-workflow-log.py` and save the JSON to
+   `/tmp/wf-<id>.json`. Tolerate fetch failures with a warning; continue.
+   Emit `>>> Workflows parsed: <N>`.
+
+3. **Parse session transcripts up to the cap.** For each run, check for a
+   `claude-transcript` artifact. Download, unzip under
+   `/tmp/transcripts/<id>/`, and run `parse-claude-transcript.py` against
+   the directory; save to `/tmp/tx-<id>.json`. Stop after
+   `CONVERSATION_LIMIT` successful parses. Emit `>>> Conversations analyzed:
+   <N> / <CONVERSATION_LIMIT>`.
+
+4. **Cluster into candidates.** Read every `/tmp/wf-*.json` and
+   `/tmp/tx-*.json`, then group related signals into distinct **problem
+   candidates**. Use the following categories (pick the best fit):
+
+   - `reliability` — errors, retries, timeouts, HTTP failures
+   - `cost_reduction` — expensive-looking multi-step LLM patterns
+   - `new_workflow` — tasks that recur and could become their own workflow
+   - `deterministic_script` — long tool-call chains replaceable by a script
+   - `subagent_skill` — patterns that could become a reusable subagent
+   - `capability_gap` — missing tool/permission/allowlist entry
+   - `docs_convention` — missing or misleading docs/conventions
+
+   For each candidate emit:
+
+   ```json
+   {
+     "title": "<short imperative>",
+     "category": "<one of the categories above>",
+     "key": "<stable slug derived deterministically from normalized title + category>",
+     "confidence": "low|medium|high",
+     "evidence": [
+       { "run_id": "<id>", "source": "workflow_log|transcript", "excerpt": "<≤160 chars>" },
+       ...
+     ]
+   }
+   ```
+
+5. **Filter low-signal candidates.** Require **≥ 2 observations** OR **1
+   high-confidence observation with strong evidence** before emitting a
+   candidate. Drop everything else silently (it will surface next run if
+   the problem is real).
+
+6. **Return the candidate list as a single JSON array** in your final
+   message to the caller. Wrap nothing else around it — the caller parses
+   the response programmatically. The final message body must match::
+
+       ```json
+       [
+         { ... },
+         { ... }
+       ]
+       ```
+
+   Also print the three `>>>` progress lines to stdout during execution so
+   the run log carries the counts.
+
+---
+
+## Hard constraints
+
+- **Never** try to extract signals by reading raw log text yourself — always
+  pipe through `parse-workflow-log.py`. The script is the single source of
+  truth for what counts as an "error" or a "tool denial", so all runs stay
+  comparable over time.
+- **Never** skip the transcript parser and count tool calls by hand.
+- Do not create, edit, or comment on any GitHub issue or PR. That is the
+  caller's job.
+- Do not modify files under `.github/workflows/`, `.env`, `*.key`, `*.pem`,
+  or `credentials.*`.
+- If both `Workflows parsed` and `Conversations analyzed` are 0, return an
+  empty JSON array `[]` and stop.

--- a/.github/workflows/auto-improve.yml
+++ b/.github/workflows/auto-improve.yml
@@ -66,6 +66,7 @@ jobs:
           claude_args: >-
             --model ${{ steps.model.outputs.id }}
             --allowed-tools
+            Task,
             Bash(gh api:*),
             Bash(gh run:*),
             Bash(gh pr:*),
@@ -73,7 +74,6 @@ jobs:
             Bash(gh label:*),
             Bash(jq:*),
             Bash(git *),
-            Bash(pip install*),
             Bash(python3 *),
             Bash(mkdir *),
             Bash(cat *),

--- a/auto_tune_config.yml
+++ b/auto_tune_config.yml
@@ -12,8 +12,6 @@ models:
   code_review: "opus"
   # Model used by the auto-improve workflow
   auto_improve: "opus"
-  # Model used by the log/transcript parsing scripts (cheaper, fast)
-  log_parser: "haiku"
 
 # Alias → full model ID mapping. Update here when new versions are released.
 # Scripts fall back to these built-in defaults if this section is absent.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,8 +33,8 @@ Both paths share the same `CLAUDE.md`, `.claude/settings.json`, and `auto_tune_c
 The `auto-improve` workflow is what makes this a *self-tuning* workspace:
 
 1. Collect recent run history (workflow logs in full; session transcripts capped by `auto_improve.default_conversation_limit`).
-2. Compact it through the `scripts/parse-*.py` helpers, which call the cheap model configured as `models.log_parser` for structured insight extraction.
-3. Feed the result into Claude with `scripts/auto-improve-prompt.md`.
+2. Compact it through the **deterministic** `scripts/parse-*.py` helpers (regex/counters only; no LLM calls, no credentials).
+3. Feed the result into Claude with `scripts/auto-improve-prompt.md`, which delegates the clustering/reasoning step to the `workflow-insights-extractor` subagent (`.claude/agents/workflow-insights-extractor.md`) via the Task tool. That subagent is the *only* component that reasons over the deterministic signals.
 4. Reconcile findings against a long-term issue tracker (one persistent GitHub issue per improvement subject, carrying an `auto-improve:<state>` label) and, where possible, open a focused fix PR linked to its issue. Issues are only closed after `tracking.verify_runs` successive clean runs confirm the problem is gone.
 
 A second, narrower loop — the daily **docs-sync** agent defined by `scripts/docs-sync-prompt.md` — keeps pages under `docs/` aligned with recent `main` commits via the routing rules in [`docs/.docsrules`](https://github.com/damien-robotsix/claude_auto_tune/blob/main/docs/.docsrules). It never touches code.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,7 +16,6 @@ models:
   claude_code: "opus"   # main claude.yml workflow
   code_review: "opus"   # code-review workflow
   auto_improve: "opus"  # auto-improve workflow
-  log_parser: "haiku"   # log/transcript parsing scripts (cheaper, fast)
 ```
 
 You can use a short alias (`haiku`, `sonnet`, `opus`) or pin a full model ID (for example `claude-sonnet-4-6`).

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -38,5 +38,6 @@ Supporting scripts live in [`scripts/`](https://github.com/damien-robotsix/claud
 - `auto-improve-prompt.md` — the prompt used by the auto-improve tracker.
 - `docs-sync-prompt.md` — the prompt used by the daily docs-sync agent.
 - `collect-doc-relevant-diff.sh` — emits the commit list and unified diff the docs-sync agent consumes from `.scratch/`.
-- `parse-claude-transcript.py` — parses Claude Code session transcripts into a compact summary, then calls the model configured as `models.log_parser` for structured insight extraction.
-- `parse-workflow-log.py` — parses raw workflow logs and calls the same `models.log_parser` model for insight extraction.
+- `parse-claude-transcript.py` — **deterministic** aggregator over Claude Code session JSONL files. Emits tool-call counts, error tools, repeated consecutive runs, token usage, and a sequence preview. No LLM calls.
+- `parse-workflow-log.py` — **deterministic** regex-based signal extractor over raw GitHub Actions logs. Emits counts and samples for errors, tool denials, workflow-permission rejections, HTTP errors, non-zero exits, retries, timeouts, and rate limits. No LLM calls.
+- All LLM-side reasoning over the output of these two scripts is handled by the `workflow-insights-extractor` subagent at [`.claude/agents/workflow-insights-extractor.md`](https://github.com/damien-robotsix/claude_auto_tune/blob/main/.claude/agents/workflow-insights-extractor.md), which the auto-improve tracker invokes via the Task tool.

--- a/scripts/auto-improve-prompt.md
+++ b/scripts/auto-improve-prompt.md
@@ -88,69 +88,54 @@ normalized problem title + category.
 
 ---
 
-## Step 1 — Discover data
+## Step 1 — Discover data (delegated to the extractor subagent)
 
-Fetch runs and parse them exactly as in the previous tracker generation.
+**You do not extract signals yourself.** Raw log and transcript parsing is
+handled by two deterministic scripts (`scripts/parse-workflow-log.py`,
+`scripts/parse-claude-transcript.py`) that are driven by a dedicated
+subagent: `workflow-insights-extractor` (see
+`.claude/agents/workflow-insights-extractor.md`). This separation keeps the
+extraction deterministic and comparable across runs, while the subagent does
+the LLM-side clustering.
 
-```bash
-pip install -q anthropic pyyaml
+Invoke the subagent via the Task tool with a prompt like:
 
-gh api repos/$GITHUB_REPOSITORY/actions/runs \
-  --paginate \
-  --jq '.workflow_runs[] | {id: .id, name: .name, created_at: .created_at, conclusion: .conclusion}' \
-  > /tmp/runs.jsonl
-echo ">>> Total runs discovered: $(wc -l < /tmp/runs.jsonl)"
+> Run the workflow-insights-extractor procedure. CONVERSATION_LIMIT=`$CONVERSATION_LIMIT`.
+> Discover all workflow runs, pipe every run's log through
+> `parse-workflow-log.py`, parse up to CONVERSATION_LIMIT Claude Code
+> session transcripts with `parse-claude-transcript.py`, cluster the
+> signals, and return the problem candidates as a JSON array.
 
-RUN_IDS=$(jq -r '.id' /tmp/runs.jsonl)
+The subagent returns a JSON array of **problem candidates**, each shaped:
 
-WORKFLOWS_PARSED=0
-for RUN_ID in $RUN_IDS; do
-  gh run view "$RUN_ID" --log 2>/dev/null \
-    | python3 scripts/parse-workflow-log.py \
-    >> /tmp/all-insights.jsonl \
-    || echo '{"summary":"fetch failed","insights":[]}' >> /tmp/all-insights.jsonl
-  WORKFLOWS_PARSED=$((WORKFLOWS_PARSED + 1))
-done
-echo ">>> Workflows parsed: $WORKFLOWS_PARSED"
-
-CONVERSATIONS_ANALYZED=0
-for RUN_ID in $RUN_IDS; do
-  if [ "$CONVERSATIONS_ANALYZED" -ge "$CONVERSATION_LIMIT" ]; then break; fi
-  ARTIFACT_ID=$(gh api repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/artifacts \
-    --jq '.artifacts[] | select(.name == "claude-transcript") | .id' 2>/dev/null | head -1)
-  if [ -z "$ARTIFACT_ID" ]; then continue; fi
-  mkdir -p /tmp/transcripts/$RUN_ID
-  gh api repos/$GITHUB_REPOSITORY/actions/artifacts/$ARTIFACT_ID/zip \
-    > /tmp/transcripts/$RUN_ID/transcript.zip 2>/dev/null
-  unzip -q /tmp/transcripts/$RUN_ID/transcript.zip -d /tmp/transcripts/$RUN_ID/ 2>/dev/null || true
-  python3 scripts/parse-claude-transcript.py /tmp/transcripts/$RUN_ID/ \
-    >> /tmp/all-transcript-insights.jsonl \
-    || echo '{"summary":"parse failed","tool_call_count":0,"top_tools":[],"insights":[]}' \
-       >> /tmp/all-transcript-insights.jsonl
-  CONVERSATIONS_ANALYZED=$((CONVERSATIONS_ANALYZED + 1))
-done
-echo ">>> Conversations analyzed: $CONVERSATIONS_ANALYZED (cap: $CONVERSATION_LIMIT)"
+```json
+{
+  "title": "<short imperative>",
+  "category": "reliability|cost_reduction|new_workflow|deterministic_script|subagent_skill|capability_gap|docs_convention",
+  "key": "<stable slug>",
+  "confidence": "low|medium|high",
+  "evidence": [
+    { "run_id": "<id>", "source": "workflow_log|transcript", "excerpt": "<≤160 chars>" }
+  ]
+}
 ```
 
-If both counts are 0, skip to Step 7 and exit without touching issues.
+The subagent is already responsible for filtering low-signal candidates
+(`≥ 2 observations` OR `1 high-confidence observation with strong evidence`),
+so every item it returns is a real candidate you should reconcile.
+
+If the subagent returns an empty array `[]`, skip to Step 7 and exit without
+touching issues. Parse its other stdout (`>>> Total runs discovered`,
+`>>> Workflows parsed`, `>>> Conversations analyzed`) to populate the run
+summary counters in Step 7.
 
 ---
 
-## Step 2 — Cluster raw insights into problem candidates
+## Step 2 — (intentionally absorbed into Step 1)
 
-Read `/tmp/all-insights.jsonl` and `/tmp/all-transcript-insights.jsonl`, group
-related entries, and produce a list of **problem candidates** in memory. Each
-candidate has:
-
-- `title` — short imperative description
-- `category` — one of the categories from the fingerprint table
-- `key` — stable slug you generate from the title + category
-- `evidence` — list of `{run_id, excerpt}` tuples (at least 1)
-- `confidence` — low / medium / high
-
-Require **≥ 2 observations** OR **1 high-confidence observation with strong
-evidence** before a candidate can become an issue. Lower-signal candidates are
-discarded this run (they'll surface again next week if the problem is real).
+Clustering into candidates is performed by the
+`workflow-insights-extractor` subagent in Step 1. You start Step 3 directly
+from its returned candidate list.
 
 ---
 

--- a/scripts/parse-claude-transcript.py
+++ b/scripts/parse-claude-transcript.py
@@ -1,136 +1,47 @@
 #!/usr/bin/env python3
 """
-Parse a Claude Code session transcript (JSONL) using Claude Haiku.
+Deterministic Claude Code session-transcript signal extractor.
 
-Claude Code saves session transcripts as JSONL files under:
-  ~/.claude/projects/<encoded-path>/<session-id>.jsonl
+Claude Code saves session transcripts as JSONL files under::
 
-Each line is a JSON object representing one turn (user, assistant, or tool result).
-This script reads that JSONL, extracts a tool-call summary, then sends it to
-Haiku for structured insight extraction.
+    ~/.claude/projects/<encoded-path>/<session-id>.jsonl
 
-Usage:
+Each line is a JSON object representing one turn (user, assistant, or tool
+result). This script walks one or more such files and emits a structured
+JSON summary of tool-call activity: total counts, top tools, failed tools,
+repeated consecutive runs, token usage, and a short sequence preview.
+
+It is **pure aggregation** — no LLM calls, no credentials, no network. All
+reasoning over this summary is the job of the ``workflow-insights-extractor``
+subagent that calls this script.
+
+Usage::
+
     cat ~/.claude/projects/**/*.jsonl | python3 scripts/parse-claude-transcript.py
     python3 scripts/parse-claude-transcript.py <transcript-file.jsonl>
     python3 scripts/parse-claude-transcript.py <dir-of-jsonl-files/>
 """
 
 import json
-import sys
-import os
 import pathlib
+import sys
 from collections import Counter
 
-try:
-    import anthropic
-except ImportError:
-    sys.exit("anthropic package not found. Run: pip install anthropic")
 
+# Cap on how many items of each list we include in the output. Counts are
+# always exact; samples are truncated so the downstream subagent prompt
+# stays small.
+TOP_N = 20
+SEQUENCE_PREVIEW_LEN = 100
 
-def _have_real_api_key() -> bool:
-    """Return True when a usable ANTHROPIC_API_KEY is set in the environment.
-
-    Inside ``anthropics/claude-code-action@v1`` the Action exports
-    ``ANTHROPIC_API_KEY=""`` (empty string) and expects the harness to use
-    OAuth via ``CLAUDE_CODE_OAUTH_TOKEN``. That OAuth token is **not** accepted
-    by the public ``api.anthropic.com`` endpoint — direct SDK calls with it
-    return ``401 OAuth authentication is currently not supported``. So the
-    only credential that actually lets this script call Haiku is a real API
-    key set via the ``ANTHROPIC_API_KEY`` secret in the workflow env.
-    """
-    return bool(os.environ.get("ANTHROPIC_API_KEY"))
-
-
-def _build_anthropic_client() -> "anthropic.Anthropic":
-    """Construct an Anthropic client backed by a real API key.
-
-    Callers must gate this behind :func:`_have_real_api_key` — we no longer
-    fall back to ``CLAUDE_CODE_OAUTH_TOKEN`` because the public Anthropic API
-    rejects OAuth tokens with 401.
-    """
-    if os.environ.get("ANTHROPIC_BASE_URL", None) == "":
-        os.environ.pop("ANTHROPIC_BASE_URL", None)
-    return anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
-
-_DEFAULT_MODEL_ALIASES = {
-    "haiku": "claude-haiku-4-5-20251001",
-    "sonnet": "claude-sonnet-4-6",
-    "opus": "claude-opus-4-6",
-}
-
-
-def _load_config() -> dict:
-    """Load auto_tune_config.yml from the repo root (two levels up from scripts/)."""
-    config_path = pathlib.Path(__file__).parent.parent / "auto_tune_config.yml"
-    if not config_path.exists():
-        return {}
-    try:
-        import yaml
-        return yaml.safe_load(config_path.read_text()) or {}
-    except Exception:
-        return {}
-
-
-_CONFIG = _load_config()
-
-
-def _resolve_model(name: str) -> str:
-    """Return the full model ID for a short alias, or the name as-is.
-
-    Aliases are read from ``model_aliases`` in auto_tune_config.yml; the
-    built-in defaults are used when that section is absent.
-    """
-    aliases = _CONFIG.get("model_aliases", _DEFAULT_MODEL_ALIASES)
-    return aliases.get(name.lower(), name)
-
-
-SYSTEM_PROMPT = """You are an expert at analyzing Claude Code AI agent session transcripts.
-Your job is to identify patterns, inefficiencies, and improvement opportunities from
-sequences of tool calls made by Claude Code during a task.
-
-Focus on:
-1. Repeated or redundant tool calls — could be cached or avoided
-2. Long tool call chains to accomplish simple tasks — candidates for helper scripts
-3. Failed tool calls or error-recovery loops — reliability improvements
-4. Missing tools that Claude worked around — capability gaps
-5. Expensive multi-step patterns that a single deterministic script could replace
-"""
-
-EXTRACT_PROMPT = """Analyze this Claude Code session tool-call summary.
-
-The summary shows which tools were called, how many times, and any notable patterns
-extracted from the JSONL transcript.
-
-Extract improvement opportunities as JSON with this exact structure:
-{{
-  "summary": "<one sentence: what task this session accomplished>",
-  "tool_call_count": <total number of tool calls>,
-  "top_tools": [<list of top 5 tool names by call count>],
-  "insights": [
-    {{
-      "category": "<one of: new_workflow | deterministic_script | subagent_skill | cost_reduction | reliability | capability_gap>",
-      "title": "<short title>",
-      "description": "<specific actionable description referencing the tool call patterns>",
-      "priority": "<high | medium | low>"
-    }}
-  ]
-}}
-
-Only include insights with clear evidence from the transcript. Return valid JSON only.
-
-Session tool-call summary:
----
-{transcript_summary}
----"""
 
 def extract_tool_calls(lines: list[str]) -> dict:
-    """Parse JSONL transcript lines and extract tool call statistics."""
+    """Walk JSONL lines and return a structured activity summary."""
     tool_counter: Counter = Counter()
     error_tools: list[str] = []
     tool_sequences: list[str] = []
     total_input_tokens = 0
     total_output_tokens = 0
-    session_summary = ""
 
     for raw in lines:
         raw = raw.strip()
@@ -141,7 +52,8 @@ def extract_tool_calls(lines: list[str]) -> dict:
         except json.JSONDecodeError:
             continue
 
-        # Claude Code JSONL wraps messages: {"type": "assistant", "message": {...}}
+        # Claude Code JSONL wraps messages:
+        #   {"type": "assistant", "message": {...}}
         # Fall back to top-level role/content for older formats.
         msg = entry.get("message", entry)
         role = msg.get("role", entry.get("type", ""))
@@ -150,7 +62,6 @@ def extract_tool_calls(lines: list[str]) -> dict:
         if isinstance(content, str):
             content = [{"type": "text", "text": content}]
 
-        # Extract usage from assistant messages
         usage = msg.get("usage") or entry.get("usage", {})
         if usage:
             total_input_tokens += usage.get("input_tokens", 0)
@@ -163,38 +74,19 @@ def extract_tool_calls(lines: list[str]) -> dict:
                     tool_counter[name] += 1
                     tool_sequences.append(name)
 
-        elif role == "tool":
-            # Detect tool errors
+        elif role in ("tool", "user"):
+            # Tool results are delivered as either role="tool" (older) or
+            # role="user" with tool_result blocks (current). Detect errors
+            # either way.
             for block in content if isinstance(content, list) else []:
                 if isinstance(block, dict) and block.get("type") == "tool_result":
-                    if block.get("is_error"):
-                        # Map back to the tool name via the preceding sequence entry
-                        if tool_sequences:
-                            error_tools.append(tool_sequences[-1])
+                    if block.get("is_error") and tool_sequences:
+                        error_tools.append(tool_sequences[-1])
 
-    # Build a readable summary for Haiku
-    lines_out: list[str] = []
-
-    if total_input_tokens or total_output_tokens:
-        lines_out.append(
-            f"Token usage: {total_input_tokens} input, {total_output_tokens} output"
-        )
-
-    lines_out.append(f"Total tool calls: {sum(tool_counter.values())}")
-
-    if tool_counter:
-        lines_out.append("\nTool call counts (descending):")
-        for tool, count in tool_counter.most_common(20):
-            lines_out.append(f"  {tool}: {count}")
-
-    if error_tools:
-        error_counts = Counter(error_tools)
-        lines_out.append("\nFailed tool calls:")
-        for tool, count in error_counts.most_common():
-            lines_out.append(f"  {tool}: {count} error(s)")
-
-    # Detect repeated sequences (runs of 3+ identical consecutive calls)
-    repeated: list[str] = []
+    # Repeated consecutive-run detection: runs of 3+ identical calls in a
+    # row are a strong signal that a loop could be replaced by a single
+    # deterministic script.
+    repeated: list[dict] = []
     i = 0
     while i < len(tool_sequences):
         j = i
@@ -202,79 +94,44 @@ def extract_tool_calls(lines: list[str]) -> dict:
             j += 1
         run_len = j - i
         if run_len >= 3:
-            repeated.append(f"  {tool_sequences[i]} called {run_len}x in a row")
+            repeated.append({"tool": tool_sequences[i], "run_length": run_len, "start_index": i})
         i = j
-    if repeated:
-        lines_out.append("\nRepeated consecutive calls:")
-        lines_out.extend(repeated)
 
-    # Truncate sequence to show first 100 tool calls
-    if tool_sequences:
-        seq_preview = " → ".join(tool_sequences[:100])
-        if len(tool_sequences) > 100:
-            seq_preview += f" ... (+{len(tool_sequences) - 100} more)"
-        lines_out.append(f"\nTool call sequence (first 100):\n  {seq_preview}")
+    error_counter = Counter(error_tools)
+
+    preview = tool_sequences[:SEQUENCE_PREVIEW_LEN]
+    sequence_preview = " → ".join(preview)
+    if len(tool_sequences) > SEQUENCE_PREVIEW_LEN:
+        sequence_preview += f" … (+{len(tool_sequences) - SEQUENCE_PREVIEW_LEN} more)"
 
     return {
-        "text": "\n".join(lines_out),
-        "total_calls": sum(tool_counter.values()),
+        "tool_call_count": sum(tool_counter.values()),
         "top_tools": [t for t, _ in tool_counter.most_common(5)],
-    }
-
-
-def parse_transcript(summary_text: str) -> dict:
-    client = _build_anthropic_client()
-
-    prompt = EXTRACT_PROMPT.format(transcript_summary=summary_text)
-
-    _alias = _CONFIG.get("models", {}).get("log_parser", "haiku")
-    message = client.messages.create(
-        model=_resolve_model(_alias),
-        max_tokens=1024,
-        system=SYSTEM_PROMPT,
-        messages=[{"role": "user", "content": prompt}],
-    )
-
-    raw = message.content[0].text.strip()
-
-    # Strip markdown code fences if present
-    if raw.startswith("```"):
-        raw_lines = raw.split("\n")
-        raw = "\n".join(raw_lines[1:-1] if raw_lines[-1] == "```" else raw_lines[1:])
-
-    return json.loads(raw)
-
-
-def _deterministic_result(extracted: dict) -> dict:
-    """Build a no-LLM fallback result from the deterministic tool-call summary.
-
-    Used when ``ANTHROPIC_API_KEY`` is not set or when the Haiku call fails.
-    The downstream tracker can still cluster on tool-call counts and top
-    tools; it just won't get LLM-authored insights for this session.
-    """
-    return {
-        "summary": "deterministic fallback — LLM parser unavailable",
-        "tool_call_count": extracted["total_calls"],
-        "top_tools": extracted["top_tools"],
-        "insights": [],
+        "tool_counts": dict(tool_counter.most_common(TOP_N)),
+        "error_tools": dict(error_counter.most_common(TOP_N)),
+        "repeated_sequences": repeated[:TOP_N],
+        "token_usage": {
+            "input_tokens": total_input_tokens,
+            "output_tokens": total_output_tokens,
+        },
+        "tool_sequence_preview": sequence_preview,
     }
 
 
 def collect_jsonl_lines(source: str) -> list[str]:
-    """Collect all JSONL lines from a file, directory, or stdin."""
+    """Collect all JSONL lines from a file, directory, or stdin sentinel."""
     p = pathlib.Path(source)
     if p.is_dir():
         lines: list[str] = []
         for jf in sorted(p.rglob("*.jsonl")):
             lines.extend(jf.read_text(errors="replace").splitlines())
         return lines
-    elif p.is_file():
+    if p.is_file():
         return p.read_text(errors="replace").splitlines()
-    else:
-        return []
+    return []
 
 
-def main():
+def main() -> None:
     if len(sys.argv) > 1:
         all_lines: list[str] = []
         for arg in sys.argv[1:]:
@@ -283,29 +140,19 @@ def main():
         all_lines = sys.stdin.read().splitlines()
 
     if not any(line.strip() for line in all_lines):
-        print(json.dumps({"summary": "empty transcript", "tool_call_count": 0, "top_tools": [], "insights": []}))
+        print(json.dumps({
+            "tool_call_count": 0,
+            "top_tools": [],
+            "tool_counts": {},
+            "error_tools": {},
+            "repeated_sequences": [],
+            "token_usage": {"input_tokens": 0, "output_tokens": 0},
+            "tool_sequence_preview": "",
+            "note": "empty transcript",
+        }))
         return
 
-    extracted = extract_tool_calls(all_lines)
-
-    if extracted["total_calls"] == 0:
-        print(json.dumps({"summary": "no tool calls found", "tool_call_count": 0, "top_tools": [], "insights": []}))
-        return
-
-    if not _have_real_api_key():
-        # Running inside claude-code-action (OAuth-only) or with no creds at
-        # all. Degrade gracefully: emit the deterministic tool-call summary so
-        # the tracker pipeline still gets signal.
-        print(json.dumps(_deterministic_result(extracted), indent=2))
-        return
-
-    try:
-        result = parse_transcript(extracted["text"])
-    except anthropic.AuthenticationError:
-        # Safety net: even with ANTHROPIC_API_KEY set, the key may be revoked
-        # or wrong. Don't crash the whole tracker over one bad session.
-        print(json.dumps(_deterministic_result(extracted), indent=2))
-        return
+    result = extract_tool_calls(all_lines)
     print(json.dumps(result, indent=2))
 
 

--- a/scripts/parse-workflow-log.py
+++ b/scripts/parse-workflow-log.py
@@ -1,170 +1,164 @@
 #!/usr/bin/env python3
 """
-Parse a GitHub Actions workflow log using Claude Haiku.
+Deterministic workflow-log signal extractor.
 
-Reads log text from stdin (or a file passed as argument), calls the Haiku
-model to extract structured improvement insights, and prints JSON to stdout.
+Reads a GitHub Actions workflow log from stdin (or a file passed as argument)
+and emits a structured JSON summary of signals relevant to the
+auto-improvement tracker. This script is **pure regex/pattern extraction** —
+it never calls an LLM, never requires credentials, and never fails open on
+missing dependencies. All reasoning over these signals is the job of the
+``workflow-insights-extractor`` subagent that calls this script.
 
 Usage:
     gh run view <run-id> --log | python3 scripts/parse-workflow-log.py
     python3 scripts/parse-workflow-log.py <log-file>
+
+Output: a single JSON object on stdout with the shape documented in
+``EXPECTED_SCHEMA`` below.
 """
 
 import json
+import re
 import sys
-import os
-import pathlib
-
-try:
-    import anthropic
-except ImportError:
-    sys.exit("anthropic package not found. Run: pip install anthropic")
+from collections import Counter
+from typing import Iterable
 
 
-def _have_real_api_key() -> bool:
-    """Return True when a usable ANTHROPIC_API_KEY is set.
-
-    Inside ``anthropics/claude-code-action@v1`` the Action exports
-    ``ANTHROPIC_API_KEY=""`` and expects harness callers to use OAuth via
-    ``CLAUDE_CODE_OAUTH_TOKEN``. That OAuth token is **not** accepted by the
-    public ``api.anthropic.com`` endpoint — direct SDK calls with it return
-    ``401 OAuth authentication is currently not supported``. So the only
-    credential that actually lets this script call Haiku is a real API key
-    set via an ``ANTHROPIC_API_KEY`` secret in the workflow env.
-    """
-    return bool(os.environ.get("ANTHROPIC_API_KEY"))
-
-
-def _build_anthropic_client() -> "anthropic.Anthropic":
-    """Construct an Anthropic client backed by a real API key.
-
-    Callers must gate this behind :func:`_have_real_api_key` — we no longer
-    fall back to ``CLAUDE_CODE_OAUTH_TOKEN`` because the public Anthropic API
-    rejects OAuth tokens with 401.
-    """
-    if os.environ.get("ANTHROPIC_BASE_URL", None) == "":
-        os.environ.pop("ANTHROPIC_BASE_URL", None)
-    return anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
-
-_DEFAULT_MODEL_ALIASES = {
-    "haiku": "claude-haiku-4-5-20251001",
-    "sonnet": "claude-sonnet-4-6",
-    "opus": "claude-opus-4-6",
+EXPECTED_SCHEMA = {
+    "log_bytes": "int — total bytes read",
+    "line_count": "int — total lines",
+    "counts": "dict[str, int] — total occurrences per signal category",
+    "signals": "dict[str, list[{line, text}]] — up to SAMPLE_CAP examples per category",
 }
 
+# Cap how many sample lines we keep per signal category. Counts are always
+# exact; samples are truncated so the downstream subagent prompt stays small.
+SAMPLE_CAP = 20
 
-def _load_config() -> dict:
-    """Load auto_tune_config.yml from the repo root (two levels up from scripts/)."""
-    config_path = pathlib.Path(__file__).parent.parent / "auto_tune_config.yml"
-    if not config_path.exists():
-        return {}
-    try:
-        import yaml
-        return yaml.safe_load(config_path.read_text()) or {}
-    except Exception:
-        return {}
+# Max characters of any single log line we echo back in the JSON. GitHub
+# Actions logs can contain very long single lines (e.g. uploaded base64
+# artifacts); trimming keeps the output predictable.
+LINE_CHAR_CAP = 500
 
 
-_CONFIG = _load_config()
+# --- pattern definitions ---------------------------------------------------
+#
+# Each entry is (name, compiled_regex). Order does not matter for correctness
+# but is preserved in the output for stable diffs.
+
+PATTERNS: list[tuple[str, "re.Pattern[str]"]] = [
+    # Hard failures and generic errors. We deliberately match common casings
+    # and exclude lines that merely contain the word "error" as part of a
+    # noun phrase (e.g. "error_count: 0") by requiring a colon, "!", or
+    # "failed" nearby.
+    (
+        "errors",
+        re.compile(
+            r"(?i)\b(?:error|fatal|failed|failure|traceback)\b"
+            r"(?:\s*[:!]|\s+\w)",
+        ),
+    ),
+    # Bash allowlist / tool-permission denials emitted by the claude-code
+    # harness. These are the single most actionable signal for this repo.
+    (
+        "tool_denied",
+        re.compile(
+            r"(?i)("
+            r"command requires approval"
+            r"|not (?:in|on) the allowed tools? list"
+            r"|tool use was blocked"
+            r"|permission denied by sandbox"
+            r"|bash command .* (?:blocked|rejected|denied)"
+            r")"
+        ),
+    ),
+    # The specific "GitHub App token lacks workflows permission" rejection.
+    (
+        "workflow_permission_rejected",
+        re.compile(
+            r"refusing to allow a (?:GitHub App|OAuth App) to create or update workflow",
+            re.IGNORECASE,
+        ),
+    ),
+    # HTTP client/server errors surfaced by gh/curl/requests.
+    (
+        "http_errors",
+        re.compile(r"\bHTTP[/ ]?\d\.?\d?\s+(4\d{2}|5\d{2})\b|\b(?:status|code)[:= ]\s*(4\d{2}|5\d{2})\b"),
+    ),
+    # Explicit non-zero exit code reports.
+    (
+        "exit_codes_nonzero",
+        re.compile(r"(?i)(?:exit(?:ed)?(?:\s+with)?\s+(?:code\s+)?|status\s+)(?!0\b)\d+"),
+    ),
+    # Retry markers.
+    (
+        "retries",
+        re.compile(r"(?i)\b(?:retry|retrying|attempt\s+\d+\s+of\s+\d+|backing off)\b"),
+    ),
+    # Timeouts / cancellations.
+    (
+        "timeouts",
+        re.compile(r"(?i)\b(?:timed? ?out|timeout|deadline exceeded|cancell?ed)\b"),
+    ),
+    # Rate limiting.
+    (
+        "rate_limited",
+        re.compile(r"(?i)\b(?:rate[- ]?limit(?:ed|ing)?|too many requests|429)\b"),
+    ),
+]
 
 
-def _resolve_model(name: str) -> str:
-    """Return the full model ID for a short alias, or the name as-is.
+def _clean_line(raw: str) -> str:
+    """Trim a log line for inclusion in the JSON output.
 
-    Aliases are read from ``model_aliases`` in auto_tune_config.yml; the
-    built-in defaults are used when that section is absent.
+    GitHub Actions prefixes each line with a timestamp and stream marker
+    (e.g. ``2025-10-05T12:34:56.789Z my-step\t...``). We preserve the line
+    as-is but cap its length so a single pathological line cannot blow up
+    the output.
     """
-    aliases = _CONFIG.get("model_aliases", _DEFAULT_MODEL_ALIASES)
-    return aliases.get(name.lower(), name)
+    s = raw.rstrip("\n")
+    if len(s) > LINE_CHAR_CAP:
+        s = s[:LINE_CHAR_CAP] + "…"
+    return s
 
 
-SYSTEM_PROMPT = """You are an expert at analyzing Claude Code AI agent workflow logs.
-Your job is to extract actionable improvement insights from GitHub Actions logs
-where Claude Code was invoked.
+def extract_signals(lines: Iterable[str]) -> dict:
+    counts: Counter = Counter()
+    samples: dict[str, list[dict]] = {name: [] for name, _ in PATTERNS}
+    line_count = 0
+    log_bytes = 0
 
-Focus on:
-1. Tasks that took many tool calls or a long time — potential for deterministic scripts
-2. Repeated patterns across similar tasks — candidates for new workflows or skills
-3. Expensive model usage — places where Haiku could replace Sonnet/Opus
-4. Errors, retries, or failed approaches — reliability improvements
-5. Missing capabilities that Claude had to work around manually
+    for lineno, raw in enumerate(lines, start=1):
+        line_count = lineno
+        log_bytes += len(raw)
+        for name, pat in PATTERNS:
+            if pat.search(raw):
+                counts[name] += 1
+                if len(samples[name]) < SAMPLE_CAP:
+                    samples[name].append({"line": lineno, "text": _clean_line(raw)})
 
-Be concise and specific. Each insight should be immediately actionable.
-"""
-
-EXTRACT_PROMPT = """Analyze this GitHub Actions workflow log from a Claude Code run.
-
-Extract improvement opportunities as JSON with this exact structure:
-{{
-  "summary": "<one sentence summary of what this workflow run did>",
-  "insights": [
-    {{
-      "category": "<one of: new_workflow | deterministic_script | subagent_skill | cost_reduction | reliability>",
-      "title": "<short title>",
-      "description": "<specific actionable description>",
-      "priority": "<high | medium | low>"
-    }}
-  ]
-}}
-
-Only include insights with clear evidence from the log. Return valid JSON only.
-
-Log:
----
-{log_content}
----"""
-
-def parse_log(log_content: str) -> dict:
-    client = _build_anthropic_client()
-
-    prompt = EXTRACT_PROMPT.format(log_content=log_content)
-
-    _alias = _CONFIG.get("models", {}).get("log_parser", "haiku")
-    message = client.messages.create(
-        model=_resolve_model(_alias),
-        max_tokens=1024,
-        system=SYSTEM_PROMPT,
-        messages=[{"role": "user", "content": prompt}],
-    )
-
-    raw = message.content[0].text.strip()
-
-    # Strip markdown code fences if present
-    if raw.startswith("```"):
-        lines = raw.split("\n")
-        raw = "\n".join(lines[1:-1] if lines[-1] == "```" else lines[1:])
-
-    return json.loads(raw)
+    return {
+        "log_bytes": log_bytes,
+        "line_count": line_count,
+        "counts": {name: counts.get(name, 0) for name, _ in PATTERNS},
+        "signals": samples,
+    }
 
 
-_UNAVAILABLE = {"summary": "parser unavailable (no ANTHROPIC_API_KEY)", "insights": []}
-
-
-def main():
+def main() -> None:
     if len(sys.argv) > 1:
         with open(sys.argv[1], "r", errors="replace") as f:
-            log_content = f.read()
+            result = extract_signals(f)
     else:
-        log_content = sys.stdin.read()
+        result = extract_signals(sys.stdin)
 
-    if not log_content.strip():
-        print(json.dumps({"summary": "empty log", "insights": []}))
-        return
+    if result["line_count"] == 0:
+        # Preserve a stable shape so downstream consumers can always
+        # ``.counts`` without guarding against empties.
+        result["note"] = "empty log"
 
-    if not _have_real_api_key():
-        # Running inside claude-code-action (OAuth-only) or with no creds.
-        # Degrade gracefully instead of crashing the tracker pipeline — this
-        # script has no deterministic pre-LLM extractor, so the fallback is
-        # just a valid empty-insights row.
-        print(json.dumps(_UNAVAILABLE))
-        return
-
-    try:
-        result = parse_log(log_content)
-    except anthropic.AuthenticationError:
-        print(json.dumps(_UNAVAILABLE))
-        return
-    print(json.dumps(result, indent=2))
+    json.dump(result, sys.stdout, indent=2)
+    sys.stdout.write("\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- `scripts/parse-workflow-log.py` and `scripts/parse-claude-transcript.py` are now **pure deterministic extractors** — regex/counters only, no `anthropic` import, no credentials, no network. They emit stable structured JSON (counts + samples) that is comparable across runs.
- A new **`workflow-insights-extractor` subagent** (`.claude/agents/workflow-insights-extractor.md`) owns all LLM reasoning over those signals. It fetches runs via `gh`, pipes each log/transcript through the deterministic scripts, clusters the output into problem candidates with evidence, and returns a JSON array to its caller.
- `scripts/auto-improve-prompt.md` delegates its Step 1 to the subagent via the Task tool; Step 2 (clustering) is absorbed into Step 1. The lifecycle/reconciliation logic (Steps 3–7) is unchanged.
- `.github/workflows/auto-improve.yml` now allows the `Task` tool and drops the unused `pip install` allowlist entry.
- `auto_tune_config.yml` and the three affected doc pages (`docs/workflows.md`, `docs/architecture.md`, `docs/configuration.md`) drop the stale `models.log_parser` reference and document the new split.

### Why

Before this change the parser scripts tried to call Haiku directly via the Anthropic SDK. That does not work inside `anthropics/claude-code-action@v1` — the Action exports an empty `ANTHROPIC_API_KEY` and relies on OAuth, which the public API rejects with `401 OAuth authentication is currently not supported`. In CI the scripts silently fell back to empty insights and the tracker ran blind. It also mixed deterministic signal extraction with non-deterministic LLM reasoning in the same binary, so runs were not comparable over time.

Strict separation means signals are extracted the same way every run, and the reasoning step is a purpose-built subagent that can be swapped or improved independently.

## Test plan

- [x] `python3 -c "import ast; ast.parse(...)"` on both scripts
- [x] `parse-workflow-log.py` manual run against a synthetic log — correctly classifies errors, tool denials, workflow-permission rejection, non-zero exit, retries
- [x] `parse-claude-transcript.py` manual run against a synthetic JSONL session — correctly counts tools, detects an error tool, and surfaces a 3× repeated Read sequence
- [ ] First scheduled `auto-improve.yml` run exercises the Task → subagent path end to end