### PR TITLE
ci: pin claude-code-action to immutable SHA

### DIFF
--- a/.github/workflows/auto-improve.yml
+++ b/.github/workflows/auto-improve.yml
@@ -41,7 +41,7 @@ jobs:
           echo "runs=$n" >> "$GITHUB_OUTPUT"
 
       - name: Run Auto-Improvement Tracker
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@1eddb334cfa79fdb21ecbe2180ca1a016e8e7d47  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@1eddb334cfa79fdb21ecbe2180ca1a016e8e7d47  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: 'claude'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@1eddb334cfa79fdb21ecbe2180ca1a016e8e7d47  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Run Docs Sync Agent
         if: steps.collect.outputs.has_changes == 'true'
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@1eddb334cfa79fdb21ecbe2180ca1a016e8e7d47  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Replace `anthropics/claude-code-action@v1` with `@1eddb334cfa79fdb21ecbe2180ca1a016e8e7d47  # v1` across all four workflows (`auto-improve`, `claude`, `claude-code-review`, `docs-sync`).
- The SHA is the current resolution of the upstream `v1` tag (commit "bump Claude Code to 2.1.92", 2026-04-04).
- Addresses remediation #1 from #34: pinning removes per-run tag resolution and lets the Actions runner cache the action more aggressively, reducing exposure to the 120s marketplace-cache / clone timeouts (65 signals across 36 runs in the sampled batch). It does not eliminate the action's internal clone of `anthropics/claude-code` — that's baked into the action and would need an upstream fix.

## Test plan
- [ ] CI runs on this PR succeed (claude-review workflow exercises the pinned action end-to-end).
- [ ] Spot-check a post-merge `auto-improve` or `claude` dispatch to confirm the action still bootstraps correctly.
- [ ] Monitor timeout signal counts over the next batch of runs tracked by #34.

Refs #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)