### PR TITLE
feat(hub): phase-1 cross-workspace improvement sharing (daily sweep)

### DIFF
--- a/.github/workflows/hub-daily-sweep.yml
+++ b/.github/workflows/hub-daily-sweep.yml
@@ -1,0 +1,119 @@
+name: Hub Daily Sweep
+
+# Phase 1 of the cross-workspace improvement sharing protocol (issue #32).
+# Runs daily. Uses Claude to decide which PRs merged in the last 24 hours
+# are generalizable and opens a proposal issue in the configured hub repo
+# for each. Deterministic `gh` wrappers under scripts/hub/*.py do the
+# actual data movement; Claude only provides judgment.
+#
+# This workflow is publish-only. It never adopts proposals from other
+# forks — that lives in the sibling hub-sync workflow (later phase).
+
+on:
+  schedule:
+    # Runs daily at 03:00 UTC
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+    inputs:
+      lookback:
+        description: 'Lookback window for merged PRs (e.g. 24h, 3d)'
+        required: false
+        default: '24h'
+
+jobs:
+  hub-daily-sweep:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Inject CI sandbox rules into CLAUDE.md
+        # CI-only prompt injection, mirrors auto-improve-discover.yml.
+        run: |
+          printf '\n\n' >> CLAUDE.md
+          cat docs/ci-sandbox-rules.md >> CLAUDE.md
+
+      - name: Resolve hub config from auto_tune_config.yml
+        id: hub
+        run: |
+          enabled=$(yq '.hub.enabled // false' auto_tune_config.yml)
+          repo=$(yq '.hub.repo // ""' auto_tune_config.yml)
+          echo "enabled=$enabled" >> "$GITHUB_OUTPUT"
+          echo "repo=$repo" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve model from auto_tune_config.yml
+        id: model
+        if: steps.hub.outputs.enabled == 'true' && steps.hub.outputs.repo != ''
+        run: |
+          alias=$(yq '.models.auto_improve // "opus"' auto_tune_config.yml)
+          id=$(yq ".model_aliases.\"$alias\" // \"$alias\"" auto_tune_config.yml)
+          echo "id=$id" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare scratch dir
+        if: steps.hub.outputs.enabled == 'true' && steps.hub.outputs.repo != ''
+        run: mkdir -p .scratch
+
+      - name: Run Hub Daily Sweep
+        if: steps.hub.outputs.enabled == 'true' && steps.hub.outputs.repo != ''
+        uses: anthropics/claude-code-action@1eddb334cfa79fdb21ecbe2180ca1a016e8e7d47  # v1
+        env:
+          HUB_REPO: ${{ steps.hub.outputs.repo }}
+          ORIGIN_REPO: ${{ github.repository }}
+          LOOKBACK: ${{ github.event.inputs.lookback || '24h' }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          prompt: |
+            Read the file `scripts/hub-daily-sweep-prompt.md` — it
+            contains your full instructions. You are the daily sweep
+            half of the cross-workspace improvement sharing protocol.
+            Your only write operation is creating proposal issues in
+            the hub repo via `scripts/hub/hub-open-proposal.py`.
+
+            HUB_REPO=${{ steps.hub.outputs.repo }}
+            ORIGIN_REPO=${{ github.repository }}
+            LOOKBACK=${{ github.event.inputs.lookback || '24h' }}
+            Today's date: $(date +%Y-%m-%d)
+
+          claude_args: >-
+            --model ${{ steps.model.outputs.id }}
+            --allowed-tools
+            Bash(gh api:*),
+            Bash(gh pr:*),
+            Bash(gh issue:*),
+            Bash(gh label:*),
+            Bash(gh repo:*),
+            Bash(jq:*),
+            Bash(python3 *),
+            Bash(mkdir *),
+            Bash(cat *),
+            Bash(echo *),
+            Bash(ls *),
+            Bash(head *),
+            Bash(rm *),
+            Read,
+            Write,
+            Glob,
+            Grep
+
+      - name: Sweep disabled notice
+        if: steps.hub.outputs.enabled != 'true' || steps.hub.outputs.repo == ''
+        run: |
+          echo "hub.enabled is false or hub.repo is empty in auto_tune_config.yml; skipping."
+
+      - name: Upload Claude session transcript
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-transcript
+          path: ~/.claude/projects/**/*.jsonl
+          if-no-files-found: ignore
+          retention-days: 30

--- a/auto_tune_config.yml
+++ b/auto_tune_config.yml
@@ -33,3 +33,25 @@ auto_improve_verify:
   # Per-issue verify workflow cron (daily): iterates every open auto-improve
   # issue and runs a targeted before/after comparison to decide closure.
   schedule: "0 6 * * *"
+
+# Cross-workspace improvement sharing protocol (issue #32). Phase 1 is
+# publish-only: the hub-daily-sweep workflow scans PRs merged into this
+# repo's default branch and opens proposal issues in the hub repo for
+# generalizable changes. Later phases will add hub-sync (relevance check)
+# and hub-report (adoption outcome reporting).
+hub:
+  # Master switch. When false, the hub-daily-sweep workflow runs but
+  # exits immediately without touching the hub repo.
+  enabled: false
+  # Hub repo slug. All proposals this workspace creates go here.
+  repo: "damien-robotsix/claude-auto-tune-hub"
+  # Daily sweep cron — scans PRs merged in the last 24h.
+  sweep_schedule: "0 3 * * *"
+  # Uniform lifetime (days) after which proposals are archived-closed
+  # by the hub repo's own housekeeping workflow. Informational here —
+  # the enforcement lives in the hub repo, not in this workspace.
+  proposal_lifetime_days: 7
+  # Reserved for later phases. Each entry is an owner/repo whose
+  # proposals this workspace will auto-adopt via hub-sync. Unknown
+  # origins will produce draft PRs for manual review.
+  auto_adopt_from: []

--- a/docs/ci-sandbox-rules.md
+++ b/docs/ci-sandbox-rules.md
@@ -1,7 +1,8 @@
 # CI sandbox — Bash command rules
 
 When running inside `anthropics/claude-code-action@v1` (the claude.yml,
-claude-code-review.yml, auto-improve-discover.yml, and auto-improve-verify.yml workflows), Bash tool calls are
+claude-code-review.yml, auto-improve-discover.yml, auto-improve-verify.yml,
+and hub-daily-sweep.yml workflows), Bash tool calls are
 restricted to the `--allowed-tools` list in the workflow and are further
 filtered by a sandbox. To avoid wasting tool calls on rejected commands,
 follow these rules:

--- a/scripts/hub-daily-sweep-prompt.md
+++ b/scripts/hub-daily-sweep-prompt.md
@@ -1,0 +1,104 @@
+# Hub Daily Sweep Prompt
+
+You are the **daily sweep** half of the cross-workspace improvement sharing
+protocol (issue #32). Your job is to look at what merged into this repo's
+default branch in the last 24 hours and, for each change that looks
+generalizable to other `claude_auto_tune` forks, open a **proposal issue**
+in the configured hub repo.
+
+You are **not** allowed to adopt proposals from other forks in this
+workflow. That lives in the sibling `hub-sync` workflow (later phase).
+
+## Inputs from the workflow
+
+- `HUB_REPO` — e.g. `damien-robotsix/claude-auto-tune-hub`.
+- `ORIGIN_REPO` — `$GITHUB_REPOSITORY`, e.g. `damien-robotsix/claude_auto_tune`.
+- `LOOKBACK` — e.g. `24h`.
+
+## Guardrails
+
+- **Scripts never call an LLM.** You, running inside the action, are the
+  only place judgment happens. The scripts under `scripts/hub/*.py` are
+  deterministic `gh` wrappers. Never replace them with ad-hoc `gh` calls
+  for the operations they already cover.
+- **One proposal per merged PR, at most.** If multiple merged PRs
+  describe the same improvement (e.g. a revert + re-land), bundle them
+  into a single proposal and list every relevant PR in `origin_prs`.
+- **Dedupe against the hub before opening.** Use `hub-search.py` with a
+  short query derived from the candidate title. If a matching active
+  proposal already exists from this origin, skip — do not post a
+  duplicate.
+- **Skip workspace-specific changes.** Typos in `CLAUDE.md`, local
+  convention tweaks, one-off copy fixes, and PRs that only touch
+  `docs/` content that is specific to this fork's narrative are not
+  generalizable. Only propose when the change would plausibly help
+  another fork of `claude_auto_tune`.
+- **Skip auto-improve fix PRs that simply close a local tracker issue.**
+  The `auto-improve:*` label taxonomy is internal and those PRs are
+  usually too narrow to generalize. Propose only if the underlying
+  *pattern* (not the specific fix) is reusable.
+- **Never open adoption PRs from this workflow.** Your only write
+  operation is creating issues in the hub repo.
+- Observe the sandbox rules in `docs/ci-sandbox-rules.md`: one operation
+  per `Bash` call, no `2>&1`, no redirection outside the working
+  directory.
+
+## Procedure
+
+1. **List merged PRs.** Call
+   `python3 scripts/hub/list-merged-prs.py --since "$LOOKBACK"`. Read the
+   JSON array — each row has title, body, files, diff, url, labels.
+
+   If the array is empty, print `no merged PRs in window` and exit 0
+   without touching the hub.
+
+2. **For each PR, decide: generalizable?** Apply the guardrails above.
+   Err on the side of *not* proposing. A proposal that another fork
+   rejects is cheap; a noisy hub queue is expensive.
+
+3. **Dedupe.** For each generalizable PR, call
+   `python3 scripts/hub/hub-search.py --hub-repo "$HUB_REPO" --origin "$ORIGIN_REPO" --query "<3-6 key words from the title>"`
+   and read the JSON array. If any result clearly describes the same
+   improvement (same files touched + same intent), skip — log that you
+   skipped and why.
+
+4. **Draft a proposal.** For each surviving candidate, write a JSON file
+   under `./.scratch/proposal-<pr-number>.json` with this shape:
+
+   ```json
+   {
+     "title": "<short imperative summary, <=80 chars>",
+     "problem": "<1-3 sentences: what failure mode / pattern this addresses>",
+     "proposed_change": "<files touched + a short prose description; you MAY quote a few key lines from the diff>",
+     "evidence": "<the PR URL, plus any referenced issues/runs>",
+     "applicability": "<preconditions other forks need to benefit from this>",
+     "origin_repo": "<ORIGIN_REPO>",
+     "origin_prs": ["<PR URL>"],
+     "scopes": ["workflow" | "prompt" | "script" | "config", ...]
+   }
+   ```
+
+   Keep `problem` and `proposed_change` terse — the hub is an index,
+   not a mirror of the PR body.
+
+5. **Open the proposal.** Call
+   `python3 scripts/hub/hub-open-proposal.py --hub-repo "$HUB_REPO" --file ./.scratch/proposal-<pr-number>.json`.
+   The script returns JSON with the created issue URL. Record it.
+
+6. **Run summary.** Print a final summary to stdout:
+
+   ```
+   ============================================
+     Hub daily sweep — $(date +%Y-%m-%d)
+     Origin repo:        <ORIGIN_REPO>
+     Hub repo:           <HUB_REPO>
+     Merged PRs seen:    <N>
+     Generalizable:      <N>
+     Proposals opened:   <N>
+     Skipped (dedupe):   <N>
+   ============================================
+   ```
+
+No follow-up actions. The hub-side archive workflow (to be added in a
+later phase, lives in the hub repo) is responsible for closing
+proposals after 7 days. You never close or modify proposals yourself.

--- a/scripts/hub/hub-open-proposal.py
+++ b/scripts/hub/hub-open-proposal.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""
+Deterministic opener for hub improvement proposals.
+
+Reads a structured proposal description from a YAML (or JSON) file and
+creates a corresponding issue in the configured hub repo, applying the
+canonical label set:
+
+- ``status:active``
+- ``origin:<owner>/<repo>`` (derived from the proposal file or
+  ``$GITHUB_REPOSITORY``)
+- ``scope:<workflow|prompt|script|config>`` (one per distinct scope
+  declared in the proposal)
+
+Missing labels are created on demand (``gh label create --force``) so
+the hub repo does not need to be pre-seeded.
+
+Input file shape (YAML)::
+
+    title: "short imperative summary"
+    problem: |
+        What pattern / failure mode this addresses.
+    evidence: |
+        Links to PRs, runs, transcripts that back the proposal.
+    proposed_change: |
+        File paths + a diff or prose description.
+    applicability: |
+        Preconditions (e.g. "requires docker harness",
+        "only relevant if auto-improve runs on a schedule").
+    origin_repo: damien-robotsix/claude_auto_tune
+    origin_prs:
+      - https://github.com/.../pull/42
+    scopes:
+      - workflow
+      - script
+
+JSON with the same keys is also accepted.
+
+This script is a pure orchestration of ``gh``. It **never** calls an LLM.
+All judgment ("is this proposal worth opening?", "what is its scope?")
+lives in the workflow layer that invokes this script.
+
+Usage::
+
+    python3 scripts/hub/hub-open-proposal.py \\
+        --hub-repo damien-robotsix/claude-auto-tune-hub \\
+        --file /tmp/proposal-123.yaml
+
+    # dry-run: print the rendered body and labels without calling gh
+    python3 scripts/hub/hub-open-proposal.py \\
+        --hub-repo damien-robotsix/claude-auto-tune-hub \\
+        --file /tmp/proposal-123.yaml \\
+        --dry-run
+
+Exit codes:
+    0  success
+    2  usage / input error
+    3  ``gh`` CLI not installed or not authenticated
+    4  proposal file failed schema validation
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+REQUIRED_FIELDS = ("title", "problem", "proposed_change")
+ALLOWED_SCOPES = {"workflow", "prompt", "script", "config"}
+
+
+def _run_gh(args: list[str], stdin: str | None = None) -> tuple[int, str, str]:
+    try:
+        proc = subprocess.run(
+            ["gh", *args],
+            input=stdin,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return 127, "", "gh CLI not found on PATH"
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def load_proposal(path: str) -> tuple[dict, str | None]:
+    try:
+        with open(path, "r") as f:
+            raw = f.read()
+    except OSError as exc:
+        return {}, f"could not read {path}: {exc}"
+
+    # Prefer YAML if available; fall back to JSON. We keep the YAML
+    # dependency optional so the script runs in minimal CI images.
+    try:
+        import yaml  # type: ignore
+
+        data = yaml.safe_load(raw)
+    except ImportError:
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            return (
+                {},
+                (
+                    f"{path} is not valid JSON and PyYAML is not "
+                    f"installed: {exc}"
+                ),
+            )
+    except Exception as exc:  # pragma: no cover - yaml error surface
+        return {}, f"yaml parse error in {path}: {exc}"
+
+    if not isinstance(data, dict):
+        return {}, f"{path} must contain a mapping at the top level"
+    return data, None
+
+
+def validate(proposal: dict) -> str | None:
+    for key in REQUIRED_FIELDS:
+        value = proposal.get(key)
+        if not isinstance(value, str) or not value.strip():
+            return f"missing required field: {key}"
+    scopes = proposal.get("scopes") or []
+    if not isinstance(scopes, list):
+        return "scopes must be a list"
+    for scope in scopes:
+        if scope not in ALLOWED_SCOPES:
+            return (
+                f"scope {scope!r} not in "
+                f"{sorted(ALLOWED_SCOPES)}"
+            )
+    origin_prs = proposal.get("origin_prs") or []
+    if not isinstance(origin_prs, list):
+        return "origin_prs must be a list of URLs"
+    return None
+
+
+def resolve_origin_repo(proposal: dict) -> str | None:
+    origin = proposal.get("origin_repo")
+    if isinstance(origin, str) and origin.strip():
+        return origin.strip()
+    return os.environ.get("GITHUB_REPOSITORY")
+
+
+def render_body(proposal: dict, origin_repo: str) -> str:
+    lines: list[str] = []
+    lines.append("<!-- hub-proposal:v1 -->")
+    lines.append("")
+    lines.append("## Problem")
+    lines.append(proposal["problem"].rstrip())
+    lines.append("")
+    lines.append("## Proposed change")
+    lines.append(proposal["proposed_change"].rstrip())
+    lines.append("")
+    evidence = proposal.get("evidence")
+    if isinstance(evidence, str) and evidence.strip():
+        lines.append("## Evidence")
+        lines.append(evidence.rstrip())
+        lines.append("")
+    applicability = proposal.get("applicability")
+    if isinstance(applicability, str) and applicability.strip():
+        lines.append("## Applicability")
+        lines.append(applicability.rstrip())
+        lines.append("")
+    lines.append("## Origin")
+    lines.append(f"- Repo: `{origin_repo}`")
+    origin_prs = proposal.get("origin_prs") or []
+    if origin_prs:
+        lines.append("- PRs:")
+        for url in origin_prs:
+            lines.append(f"  - {url}")
+    lines.append("")
+    lines.append(
+        "_This proposal is part of the cross-workspace improvement "
+        "sharing protocol. It has a 7-day active lifetime and will "
+        "then be archived._"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def ensure_label(hub_repo: str, name: str, color: str, desc: str) -> None:
+    # --force makes this idempotent: creates if missing, updates if
+    # present. Failures are swallowed so a read-only token can still
+    # open proposals against a hub that already has its labels.
+    _run_gh(
+        [
+            "label",
+            "create",
+            name,
+            "--repo",
+            hub_repo,
+            "--color",
+            color,
+            "--description",
+            desc,
+            "--force",
+        ]
+    )
+
+
+def ensure_canonical_labels(
+    hub_repo: str, origin_repo: str, scopes: list[str]
+) -> list[str]:
+    """Create any labels we're about to use and return the list."""
+    labels = ["status:active", f"origin:{origin_repo}"]
+    ensure_label(
+        hub_repo,
+        "status:active",
+        "0e8a16",
+        "Within the 7-day active window",
+    )
+    ensure_label(
+        hub_repo,
+        f"origin:{origin_repo}",
+        "c5def5",
+        f"Proposed by {origin_repo}",
+    )
+    for scope in scopes:
+        label = f"scope:{scope}"
+        ensure_label(
+            hub_repo,
+            label,
+            "fbca04",
+            f"Touches {scope} surface area",
+        )
+        labels.append(label)
+    return labels
+
+
+def open_proposal(
+    hub_repo: str,
+    title: str,
+    body: str,
+    labels: list[str],
+) -> tuple[str | None, str | None]:
+    args = [
+        "issue",
+        "create",
+        "--repo",
+        hub_repo,
+        "--title",
+        title,
+        "--body-file",
+        "-",
+    ]
+    for label in labels:
+        args.extend(["--label", label])
+    rc, stdout, err = _run_gh(args, stdin=body)
+    if rc != 0:
+        return None, (err or stdout or f"gh exited with {rc}").strip()
+    url = stdout.strip().splitlines()[-1] if stdout.strip() else None
+    return url, None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Open a cross-workspace improvement proposal issue in the "
+            "hub repo from a YAML/JSON file."
+        )
+    )
+    parser.add_argument(
+        "--hub-repo",
+        required=True,
+        help="hub repo slug, e.g. damien-robotsix/claude-auto-tune-hub",
+    )
+    parser.add_argument(
+        "--file",
+        required=True,
+        help="path to the YAML or JSON proposal file",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "print the rendered title, labels, and body to stdout "
+            "instead of calling gh"
+        ),
+    )
+    args = parser.parse_args()
+
+    if not shutil.which("gh") and not args.dry_run:
+        print("error: gh CLI not found on PATH", file=sys.stderr)
+        return 3
+
+    proposal, err = load_proposal(args.file)
+    if err:
+        print(f"error: {err}", file=sys.stderr)
+        return 2
+
+    verr = validate(proposal)
+    if verr:
+        print(f"error: invalid proposal: {verr}", file=sys.stderr)
+        return 4
+
+    origin_repo = resolve_origin_repo(proposal)
+    if not origin_repo:
+        print(
+            "error: could not resolve origin_repo; set it in the "
+            "proposal file or $GITHUB_REPOSITORY",
+            file=sys.stderr,
+        )
+        return 2
+
+    title = proposal["title"].strip()
+    if not title.lower().startswith("[proposal]"):
+        title = f"[proposal] {title}"
+
+    body = render_body(proposal, origin_repo)
+    scopes = [s for s in (proposal.get("scopes") or []) if s]
+
+    if args.dry_run:
+        labels = ["status:active", f"origin:{origin_repo}"] + [
+            f"scope:{s}" for s in scopes
+        ]
+        print(f"title: {title}")
+        print(f"labels: {labels}")
+        print("body:")
+        print(body)
+        return 0
+
+    labels = ensure_canonical_labels(args.hub_repo, origin_repo, scopes)
+    url, err = open_proposal(args.hub_repo, title, body, labels)
+    if err:
+        print(f"error: gh issue create failed: {err}", file=sys.stderr)
+        return 3
+
+    result = {
+        "hub_repo": args.hub_repo,
+        "origin_repo": origin_repo,
+        "title": title,
+        "labels": labels,
+        "url": url,
+    }
+    sys.stdout.write(json.dumps(result, indent=2))
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hub/hub-search.py
+++ b/scripts/hub/hub-search.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+Deterministic dedupe helper for hub proposals.
+
+Searches the hub repo for existing ``status:active`` proposal issues
+that might match a candidate improvement, so the ``hub-daily-sweep``
+workflow can avoid opening duplicates.
+
+Given a candidate title (and optional origin-repo hint), this script
+queries the hub repo's issue index and returns a JSON array of potential
+matches, each row including:
+
+- number, title, url, state, labels, created_at, updated_at
+- body (full, so the caller can compare diffs/applicability)
+- origin_repo (parsed from the ``origin:<owner>/<repo>`` label, if any)
+
+The *judgment* of whether any of the returned rows are genuine duplicates
+is left to the caller (typically Claude inside the workflow). This script
+is a deterministic `gh` wrapper — no LLM calls.
+
+Usage::
+
+    python3 scripts/hub/hub-search.py \\
+        --hub-repo damien-robotsix/claude-auto-tune-hub \\
+        --query "refactor auto-improve verify"
+
+    # Restrict to proposals this origin has not yet responded to:
+    python3 scripts/hub/hub-search.py \\
+        --hub-repo damien-robotsix/claude-auto-tune-hub \\
+        --origin damien-robotsix/claude_auto_tune \\
+        --query "refactor auto-improve verify"
+
+Exit codes:
+    0  success (even if zero matches)
+    2  usage error
+    3  ``gh`` CLI not installed or not authenticated
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+MATCH_LIMIT = 25
+
+
+def _run_gh(args: list[str]) -> tuple[int, str, str]:
+    try:
+        proc = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return 127, "", "gh CLI not found on PATH"
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def _gh_json(args: list[str]) -> tuple[Any, str | None]:
+    rc, out, err = _run_gh(args)
+    if rc != 0:
+        return None, (err or out or f"gh exited with {rc}").strip()
+    try:
+        return json.loads(out), None
+    except json.JSONDecodeError as exc:
+        return None, f"invalid JSON from gh: {exc}"
+
+
+def search_hub(
+    hub_repo: str, query: str
+) -> tuple[list[dict], str | None]:
+    """Run `gh issue list` on the hub repo with a full-text search.
+
+    We rely on GitHub's native ``--search`` so the server side handles
+    tokenization; our job is just to shape the results.
+    """
+    search_terms = f"is:issue label:status:active {query}".strip()
+    data, err = _gh_json(
+        [
+            "issue",
+            "list",
+            "--repo",
+            hub_repo,
+            "--state",
+            "open",
+            "--search",
+            search_terms,
+            "--limit",
+            str(MATCH_LIMIT),
+            "--json",
+            (
+                "number,title,url,state,body,labels,"
+                "createdAt,updatedAt"
+            ),
+        ]
+    )
+    if err:
+        return [], err
+    out: list[dict] = []
+    for row in data or []:
+        labels = [l.get("name") for l in (row.get("labels") or [])]
+        origin = None
+        for name in labels:
+            if name and name.startswith("origin:"):
+                origin = name[len("origin:") :]
+                break
+        out.append(
+            {
+                "number": row.get("number"),
+                "title": row.get("title") or "",
+                "url": row.get("url"),
+                "state": row.get("state"),
+                "labels": labels,
+                "origin_repo": origin,
+                "created_at": row.get("createdAt"),
+                "updated_at": row.get("updatedAt"),
+                "body": row.get("body") or "",
+            }
+        )
+    return out, None
+
+
+def filter_not_responded_by(
+    rows: list[dict], origin: str
+) -> list[dict]:
+    """Drop rows the given origin has already adopted or rejected."""
+    adopted = f"adopted-by:{origin}"
+    rejected = f"rejected-by:{origin}"
+    kept: list[dict] = []
+    for row in rows:
+        labels = row.get("labels") or []
+        if adopted in labels or rejected in labels:
+            continue
+        kept.append(row)
+    return kept
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Search the hub repo for active proposals matching a "
+            "candidate improvement (dedupe helper for hub-daily-sweep)."
+        )
+    )
+    parser.add_argument(
+        "--hub-repo",
+        required=True,
+        help="hub repo slug, e.g. damien-robotsix/claude-auto-tune-hub",
+    )
+    parser.add_argument(
+        "--query",
+        required=True,
+        help=(
+            "free-text search query (typically the candidate title or "
+            "a short phrase derived from it)"
+        ),
+    )
+    parser.add_argument(
+        "--origin",
+        help=(
+            "if provided, drop results this origin has already "
+            "adopted-by:* / rejected-by:* labeled"
+        ),
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="write JSON array to this path instead of stdout",
+    )
+    args = parser.parse_args()
+
+    if not shutil.which("gh"):
+        print("error: gh CLI not found on PATH", file=sys.stderr)
+        return 3
+
+    rows, err = search_hub(args.hub_repo, args.query)
+    if err:
+        print(f"error: gh issue list failed: {err}", file=sys.stderr)
+        return 3
+
+    if args.origin:
+        rows = filter_not_responded_by(rows, args.origin)
+
+    text = json.dumps(rows, indent=2)
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(text)
+            f.write("\n")
+    else:
+        sys.stdout.write(text)
+        sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hub/list-merged-prs.py
+++ b/scripts/hub/list-merged-prs.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""
+Deterministic lister for recently-merged PRs.
+
+Lists PRs merged into the repository's default branch within a lookback
+window and emits a single JSON array to stdout. One row per PR with:
+
+- number, title, body, url, author, merged_at, merge_commit_sha
+- baseRefName, headRefName, labels
+- files: list of changed file paths (with additions/deletions)
+- diff: unified diff (truncated at DIFF_CHAR_CAP per PR)
+- diff_truncated: bool
+
+This is a pure orchestration of ``gh``. No LLM calls, no network beyond
+what ``gh`` already does, no writes. It exists so that the
+``hub-daily-sweep`` workflow's Claude agent can get a deterministic PR
+bundle in one tool call instead of chaining 10+ ``gh`` invocations.
+
+Usage::
+
+    python3 scripts/hub/list-merged-prs.py
+    python3 scripts/hub/list-merged-prs.py --since 48h
+    python3 scripts/hub/list-merged-prs.py --repo owner/name --since 24h
+    python3 scripts/hub/list-merged-prs.py --since 24h -o /tmp/merged.json
+
+Exit codes:
+    0  success (even if zero PRs matched)
+    2  usage error
+    3  ``gh`` CLI not installed or not authenticated
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+# Per-PR diff cap. Bigger diffs get truncated and flagged so the caller
+# can fetch the specific files it needs via other tools.
+DIFF_CHAR_CAP = 80_000
+
+# Max PRs we'll bundle in one call. The sweep workflow should never be
+# asked to reason about hundreds of merges at once.
+PR_LIMIT = 50
+
+
+def _run_gh(args: list[str]) -> tuple[int, str, str]:
+    try:
+        proc = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return 127, "", "gh CLI not found on PATH"
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def _gh_json(args: list[str]) -> tuple[Any, str | None]:
+    rc, out, err = _run_gh(args)
+    if rc != 0:
+        return None, (err or out or f"gh exited with {rc}").strip()
+    try:
+        return json.loads(out), None
+    except json.JSONDecodeError as exc:
+        return None, f"invalid JSON from gh: {exc}"
+
+
+_DURATION_RE = re.compile(r"^\s*(\d+)\s*([hdw])\s*$", re.IGNORECASE)
+
+
+def parse_since(value: str) -> timedelta:
+    """Parse a lookback like ``24h``, ``3d``, ``1w`` into a timedelta."""
+    m = _DURATION_RE.match(value)
+    if not m:
+        raise ValueError(
+            f"invalid --since {value!r}; expected e.g. 24h, 3d, 1w"
+        )
+    n = int(m.group(1))
+    unit = m.group(2).lower()
+    if unit == "h":
+        return timedelta(hours=n)
+    if unit == "d":
+        return timedelta(days=n)
+    return timedelta(weeks=n)
+
+
+def resolve_default_repo() -> str | None:
+    env = os.environ.get("GITHUB_REPOSITORY")
+    if env:
+        return env
+    data, err = _gh_json(["repo", "view", "--json", "nameWithOwner"])
+    if err or not data:
+        return None
+    return data.get("nameWithOwner")
+
+
+def resolve_default_branch(repo: str) -> tuple[str | None, str | None]:
+    data, err = _gh_json(
+        ["repo", "view", repo, "--json", "defaultBranchRef"]
+    )
+    if err or not data:
+        return None, err or "no repo data"
+    ref = data.get("defaultBranchRef") or {}
+    return ref.get("name"), None
+
+
+def list_merged_prs(
+    repo: str, base: str, since: datetime
+) -> tuple[list[dict], str | None]:
+    """Fetch merged PRs into ``base`` and filter by mergedAt >= since."""
+    fields = ",".join(
+        [
+            "number",
+            "title",
+            "body",
+            "url",
+            "author",
+            "mergedAt",
+            "mergeCommit",
+            "baseRefName",
+            "headRefName",
+            "labels",
+            "files",
+            "additions",
+            "deletions",
+        ]
+    )
+    data, err = _gh_json(
+        [
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "merged",
+            "--base",
+            base,
+            "--limit",
+            str(PR_LIMIT),
+            "--json",
+            fields,
+        ]
+    )
+    if err:
+        return [], err
+    out: list[dict] = []
+    for pr in data or []:
+        merged_at_str = pr.get("mergedAt")
+        if not merged_at_str:
+            continue
+        try:
+            merged_at = datetime.fromisoformat(
+                merged_at_str.replace("Z", "+00:00")
+            )
+        except ValueError:
+            continue
+        if merged_at < since:
+            continue
+        out.append(pr)
+    return out, None
+
+
+def fetch_pr_diff(
+    repo: str, number: int
+) -> tuple[str, bool, str | None]:
+    rc, stdout, err = _run_gh(
+        ["pr", "diff", str(number), "--repo", repo]
+    )
+    if rc != 0:
+        return "", False, (err or f"gh pr diff exited with {rc}").strip()
+    if len(stdout) > DIFF_CHAR_CAP:
+        return stdout[:DIFF_CHAR_CAP], True, None
+    return stdout, False, None
+
+
+def build_row(repo: str, pr: dict) -> dict:
+    number = pr.get("number")
+    files = [
+        {
+            "path": f.get("path"),
+            "additions": f.get("additions"),
+            "deletions": f.get("deletions"),
+        }
+        for f in (pr.get("files") or [])
+    ]
+    labels = [l.get("name") for l in (pr.get("labels") or [])]
+    diff, truncated, diff_err = fetch_pr_diff(repo, int(number))
+    row: dict[str, Any] = {
+        "repo": repo,
+        "number": number,
+        "title": pr.get("title") or "",
+        "body": pr.get("body") or "",
+        "url": pr.get("url"),
+        "author": (pr.get("author") or {}).get("login"),
+        "merged_at": pr.get("mergedAt"),
+        "merge_commit_sha": (pr.get("mergeCommit") or {}).get("oid"),
+        "base_ref": pr.get("baseRefName"),
+        "head_ref": pr.get("headRefName"),
+        "labels": labels,
+        "additions": pr.get("additions"),
+        "deletions": pr.get("deletions"),
+        "files": files,
+        "diff": diff,
+        "diff_truncated": truncated,
+    }
+    if diff_err:
+        row["diff_error"] = diff_err
+    return row
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "List PRs merged into the default branch within a lookback "
+            "window as a JSON array (used by the hub-daily-sweep "
+            "workflow)."
+        )
+    )
+    parser.add_argument(
+        "--since",
+        default="24h",
+        help="lookback window: e.g. 24h, 3d, 1w (default: 24h)",
+    )
+    parser.add_argument(
+        "--repo",
+        help=(
+            "owner/name slug (default: $GITHUB_REPOSITORY or gh default)"
+        ),
+    )
+    parser.add_argument(
+        "--base",
+        help=(
+            "base branch to filter on (default: the repo's default "
+            "branch)"
+        ),
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="write JSON array to this path instead of stdout",
+    )
+    args = parser.parse_args()
+
+    if not shutil.which("gh"):
+        print("error: gh CLI not found on PATH", file=sys.stderr)
+        return 3
+
+    try:
+        window = parse_since(args.since)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    repo = args.repo or resolve_default_repo()
+    if not repo:
+        print(
+            "error: could not determine repo; pass --repo owner/name",
+            file=sys.stderr,
+        )
+        return 2
+
+    base = args.base
+    if not base:
+        base, err = resolve_default_branch(repo)
+        if not base:
+            print(
+                f"error: could not resolve default branch: {err}",
+                file=sys.stderr,
+            )
+            return 2
+
+    since_dt = datetime.now(timezone.utc) - window
+    prs, err = list_merged_prs(repo, base, since_dt)
+    if err:
+        print(f"error: gh pr list failed: {err}", file=sys.stderr)
+        return 3
+
+    rows = [build_row(repo, pr) for pr in prs]
+    text = json.dumps(rows, indent=2)
+
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(text)
+            f.write("\n")
+    else:
+        sys.stdout.write(text)
+        sys.stdout.write("\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Lands the **publish-only** slice of the protocol designed in #32 (v5): a daily workflow scans PRs merged into `main`, lets Claude judge which are generalizable, and opens proposal issues in the shared hub repo `damien-robotsix/claude-auto-tune-hub` (created separately, empty).
- All data movement goes through deterministic `gh` wrappers under `scripts/hub/*.py`. **No LLM calls inside scripts.** Judgment lives in the workflow layer, matching the v2+ design direction.
- Disabled by default (`hub.enabled: false`) so merging this PR has zero runtime effect until a maintainer flips the switch.

## What's in the PR
- `scripts/hub/list-merged-prs.py` — JSON bundle of PRs merged into the default branch in a lookback window (title, body, url, files, diff).
- `scripts/hub/hub-search.py` — dedupe helper: searches the hub repo for active proposals matching a candidate, with optional `--origin` filter to drop already adopted/rejected ones.
- `scripts/hub/hub-open-proposal.py` — opens a labeled issue in the hub from a YAML/JSON proposal file. Creates `status:active`, `origin:<owner/repo>`, and `scope:*` labels on demand. Has a `--dry-run` mode.
- `.github/workflows/hub-daily-sweep.yml` — daily cron (`0 3 * * *`) + `workflow_dispatch`. Gated on `hub.enabled == true` and a non-empty `hub.repo`.
- `scripts/hub-daily-sweep-prompt.md` — full prompt the workflow feeds Claude. Spells out guardrails (skip workspace-specific changes, one proposal per PR, always dedupe first).
- `auto_tune_config.yml` — new `hub:` section (enabled, repo, sweep_schedule, proposal_lifetime_days, auto_adopt_from).
- `docs/ci-sandbox-rules.md` — names the new workflow alongside the other CI-sandboxed ones.

## Out of scope (later phases)
- `hub-sync.yml` (relevance check / adopt-reject-defer)
- `hub-report.yml` (adoption outcome reporting)
- `hub-archive.yml` (housekeeping cron, lives in the hub repo)
- Hub repo issue templates / schema / README

## Smoke tests run locally
- `python3 scripts/hub/list-merged-prs.py --since 3d --repo damien-robotsix/claude_auto_tune` → real JSON, all recent merges.
- `python3 scripts/hub/hub-open-proposal.py ... --dry-run` → valid rendered body + label list.
- End-to-end `hub-open-proposal.py` against the live hub repo created an issue, labels, and returned its URL. `hub-search.py` found it with and without `--origin` filter. Smoke-test issue then closed.

## Test plan
- [ ] Manually dispatch `hub-daily-sweep.yml` with `hub.enabled: true` and confirm it either opens a single well-formed proposal or exits with "no merged PRs in window".
- [ ] Confirm the disabled path (default) prints the skip notice and makes zero network writes to the hub.
- [ ] Confirm `hub-search.py` dedupes a re-dispatch on the same day.

Refs #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)