### PR TITLE
Audit auto_tune_config.yml: wire default_conversation_limit and drop dead keys

### DIFF
--- a/.github/workflows/auto-improve-discover.yml
+++ b/.github/workflows/auto-improve-discover.yml
@@ -50,6 +50,17 @@ jobs:
           id=$(yq ".model_aliases.\"$alias\" // \"$alias\"" auto_tune_config.yml)
           echo "id=$id" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve conversation limit
+        id: limit
+        run: |
+          override='${{ github.event.inputs.conversation_limit }}'
+          if [ -n "$override" ]; then
+            value="$override"
+          else
+            value=$(yq '.auto_improve.default_conversation_limit // 20' auto_tune_config.yml)
+          fi
+          echo "value=$value" >> "$GITHUB_OUTPUT"
+
       - name: Run Auto-Improvement Discover
         uses: anthropics/claude-code-action@1eddb334cfa79fdb21ecbe2180ca1a016e8e7d47  # v1
         with:
@@ -71,7 +82,7 @@ jobs:
             issue, dispatch the verify workflow with that issue number so
             its baseline is confirmed immediately.
 
-            CONVERSATION_LIMIT=${{ github.event.inputs.conversation_limit || '20' }}
+            CONVERSATION_LIMIT=${{ steps.limit.outputs.value }}
             Workflow logs to parse: all discoverable runs (no cap)
             Today's date: $(date +%Y-%m-%d)
 

--- a/auto_tune_config.yml
+++ b/auto_tune_config.yml
@@ -38,16 +38,6 @@ hub:
   enabled: true
   # Hub repo slug. All proposals this workspace creates go here.
   repo: "damien-robotsix/claude-auto-tune-hub"
-  # Daily sweep cron — scans PRs merged in the last 24h.
-  sweep_schedule: "0 3 * * *"
-  # Uniform lifetime (days) after which proposals are archived-closed
-  # by the hub repo's own housekeeping workflow. Informational here —
-  # the enforcement lives in the hub repo, not in this workspace.
-  proposal_lifetime_days: 7
-  # Reserved for later phases. Each entry is an owner/repo whose
-  # proposals this workspace will auto-adopt via hub-sync. Unknown
-  # origins will produce draft PRs for manual review.
-  auto_adopt_from: []
   # Local transcript publishing lane. Reuses the same hub repo as the
   # proposal lane but writes to a disjoint subtree
   # (transcripts/<workspace-slug>/<YYYY-MM-DD>/<session-id>.jsonl) and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,17 +63,15 @@ The `hub:` section configures the shared [`claude-auto-tune-hub`](https://github
 hub:
   enabled: true
   repo: "damien-robotsix/claude-auto-tune-hub"
-  sweep_schedule: "0 3 * * *"
-  proposal_lifetime_days: 7
-  auto_adopt_from: []
   local_transcripts:
     enabled: false
 ```
 
 - `hub.enabled` — master switch for every lane. When false, all hub scripts and workflows exit without touching anything.
 - `hub.repo` — slug of the shared hub repo. One repo hosts multiple disjoint data lanes (each lane owns its own directory tree or label set inside the hub).
-- `hub.sweep_schedule` / `hub.proposal_lifetime_days` / `hub.auto_adopt_from` — parameters for the improvement-proposal lane (issues in the hub, see `scripts/hub/hub-open-proposal.py` and the `hub-daily-sweep` workflow).
 - `hub.local_transcripts.enabled` — independent switch for the local-transcript publishing lane. When true, [`scripts/hub/push-local-transcripts.py`](https://github.com/damien-robotsix/claude_auto_tune/blob/main/scripts/hub/push-local-transcripts.py) copies new Claude Code session transcripts from `.claude-home/.claude/projects/` into `transcripts/<workspace-slug>/<YYYY-MM-DD>/` in the hub. Defaults to `false` so the script is a no-op until you opt in.
+
+The hub-daily-sweep cron is hardcoded in `.github/workflows/hub-daily-sweep.yml` (same reason as the auto-improve crons — `on.schedule` cannot be templated from config). Proposal lifetime enforcement lives in the hub repo itself.
 
 The two lanes share only the hub repo and the `hub.enabled` master switch. They have disjoint directory trees, disjoint scripts, and independent opt-in flags — adopting one does not commit you to the other.
 


### PR DESCRIPTION
## Summary

Addresses damien-robotsix/claude_auto_tune#51 — the audit flagged that several `auto_tune_config.yml` keys had no runtime readers (silent drift risk) and one was an outright bug (`default_conversation_limit` set in config but hardcoded to `20` in the discover workflow).

- **Dead schedule keys removed** (initial commit on this branch): `auto_improve.schedule`, `auto_improve_verify.schedule` — GitHub Actions' `on.schedule` only accepts literal values, so the real crons live in the workflow files and the config entries could silently drift.
- **`default_conversation_limit` actually wired** — new `Resolve conversation limit` step in `auto-improve-discover.yml` prefers the `workflow_dispatch` input and falls back to the config value (previously `|| '20'` literal, so the config was ignored on scheduled runs).
- **Three more dead hub keys dropped**: `hub.sweep_schedule` (cron is literal in `hub-daily-sweep.yml`), `hub.proposal_lifetime_days` (enforced in the hub repo), `hub.auto_adopt_from` (reserved for later phases, zero readers). Per `CLAUDE.md`'s "no speculative abstractions" guidance.
- `docs/configuration.md` updated to match, with a short note explaining why crons live in the workflow files.

Refs #51

## Test plan

- [ ] CI (lint/workflow validation) passes on this PR
- [ ] Manual: dispatch `auto-improve-discover` without an input and confirm it resolves `CONVERSATION_LIMIT` from `auto_tune_config.yml`
- [ ] Manual: dispatch with an explicit `conversation_limit` and confirm the override still wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)