### PR TITLE
fix: add Read-before-Write rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ This is a self-improving Claude Code workspace. Claude can be invoked locally (v
 
 ## Working on tasks
 
+- Always `Read` a file before calling `Write` or `Edit` on it — the tools reject calls on files that have not been read in the current session, and skipping this wastes a round-trip
 - Read the full task description and all available context before starting
 - Follow existing code patterns and conventions
 - Write clear, focused commit messages explaining the "why"


### PR DESCRIPTION
Add explicit guidance to always Read a file before calling Write or Edit on it, preventing tool rejections that waste round-trips. Unlike the previous attempt, this does not duplicate the CI sandbox rules.

Refs #47

Generated with [Claude Code](https://claude.ai/code)